### PR TITLE
Controller gRPC + migrations; Agent TLS client scaffold

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,6 +1,7 @@
 name: Security Audit
 
 on:
+  pull_request:
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch: {}

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -15,3 +15,8 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 dotenvy = "0.15"
 shared = { path = "../shared" }
+tonic = { version = "0.11", features = ["tls", "transport"] }
+prost = "0.12"
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/agent/build.rs
+++ b/crates/agent/build.rs
@@ -1,0 +1,8 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../../proto/swap/v1/controller_agent.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+    tonic_build::configure()
+        .build_server(false)
+        .compile(&[proto], &["../../proto"])?;
+    Ok(())
+}

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -1,10 +1,41 @@
 use anyhow::Result;
+use tonic::transport::{Channel, ClientTlsConfig, Certificate, Identity};
+
+pub mod proto {
+    tonic::include_proto!("swap.v1");
+}
+
+use proto::heartbeat_service_client::HeartbeatServiceClient;
+use proto::HeartbeatRequest;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
     let controller_url = std::env::var("CONTROLLER_URL").unwrap_or_else(|_| "https://127.0.0.1:8443".to_string());
+    let agent_cert_path = std::env::var("AGENT_CERT_PATH")?;
+    let agent_key_path = std::env::var("AGENT_KEY_PATH")?;
+    let controller_ca_path = std::env::var("CONTROLLER_CA_PATH")?;
+
     println!("agent starting; controller={controller_url}");
-    // TODO: establish outbound-only mTLS connection and heartbeat
+
+    let tls = client_tls(agent_cert_path, agent_key_path, controller_ca_path)?;
+    let channel = Channel::from_shared(controller_url)?
+        .tls_config(tls)?
+        .connect()
+        .await?;
+
+    let mut client = HeartbeatServiceClient::new(channel);
+    let req = HeartbeatRequest { agent_id: String::new(), seq: 1, monotonic_ms: 0 };
+    let _ = client.heartbeat(req).await?;
     Ok(())
+}
+
+fn client_tls(cert_path: String, key_path: String, ca_path: String) -> Result<ClientTlsConfig> {
+    use std::fs;
+    let cert = fs::read(cert_path)?;
+    let key = fs::read(key_path)?;
+    let ca = fs::read(ca_path)?;
+    let identity = Identity::from_pem(cert, key);
+    let ca = Certificate::from_pem(ca);
+    Ok(ClientTlsConfig::new().identity(identity).ca_certificate(ca).domain_name("controller"))
 }

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -22,3 +22,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 dotenvy = "0.15"
 shared = { path = "../shared" }
 http = "1"
+tonic = { version = "0.11", features = ["tls", "transport"] }
+prost = "0.12"
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/controller/build.rs
+++ b/crates/controller/build.rs
@@ -1,0 +1,8 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../../proto/swap/v1/controller_agent.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+    tonic_build::configure()
+        .build_client(false)
+        .compile(&[proto], &["../../proto"])?;
+    Ok(())
+}

--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub bind_addr: String,
+    pub grpc_bind_addr: String,
     pub database_url: String,
     pub tls_cert_path: String,
     pub tls_key_path: String,
@@ -12,11 +13,12 @@ pub struct Config {
 impl Config {
     pub fn from_env() -> anyhow::Result<Self> {
         dotenvy::dotenv().ok();
-        let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8443".to_string());
+        let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8445".to_string());
+        let grpc_bind_addr = std::env::var("GRPC_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8443".to_string());
         let database_url = std::env::var("DATABASE_URL")?;
         let tls_cert_path = std::env::var("TLS_CERT_PATH")?;
         let tls_key_path = std::env::var("TLS_KEY_PATH")?;
         let client_ca_path = std::env::var("CLIENT_CA_PATH")?;
-        Ok(Self { bind_addr, database_url, tls_cert_path, tls_key_path, client_ca_path })
+        Ok(Self { bind_addr, grpc_bind_addr, database_url, tls_cert_path, tls_key_path, client_ca_path })
     }
 }

--- a/crates/controller/src/db.rs
+++ b/crates/controller/src/db.rs
@@ -11,3 +11,10 @@ pub async fn connect(database_url: &str) -> Result<Db> {
         .await?;
     Ok(pool)
 }
+
+pub async fn migrate(pool: &Db) -> Result<()> {
+    // Embed migrations from workspace root migrations folder
+    // Path is relative to this crate (crates/controller)
+    sqlx::migrate!("../../migrations").run(pool).await?;
+    Ok(())
+}

--- a/crates/controller/src/grpc.rs
+++ b/crates/controller/src/grpc.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use sqlx::Pool;
+use sqlx::Postgres;
+use tonic::{transport::{Server, ServerTlsConfig, Identity, Certificate}, Request, Response, Status};
+
+pub mod proto {
+    tonic::include_proto!("swap.v1");
+}
+
+use proto::enrollment_service_server::{EnrollmentService, EnrollmentServiceServer};
+use proto::heartbeat_service_server::{HeartbeatService, HeartbeatServiceServer};
+use proto::desired_state_service_server::{DesiredStateService, DesiredStateServiceServer};
+use proto::plan_service_server::{PlanService, PlanServiceServer};
+use proto::log_service_server::{LogService, LogServiceServer};
+
+use proto::{EnrollmentRequest, EnrollmentResponse, HeartbeatRequest, HeartbeatResponse, DesiredStateRequest, DesiredStateUpdate, ApplyPlanRequest, ApplyPlanResult, LogEnvelope, StreamAck};
+
+#[derive(Clone)]
+pub struct ControllerSvc {
+    pub db: Pool<Postgres>,
+}
+
+#[tonic::async_trait]
+impl EnrollmentService for ControllerSvc {
+    async fn enroll(&self, _req: Request<EnrollmentRequest>) -> Result<Response<EnrollmentResponse>, Status> {
+        let resp = EnrollmentResponse { agent_id: String::new(), certificate: vec![], ca_chain: vec![] };
+        Ok(Response::new(resp))
+    }
+}
+
+#[tonic::async_trait]
+impl HeartbeatService for ControllerSvc {
+    async fn heartbeat(&self, _req: Request<HeartbeatRequest>) -> Result<Response<HeartbeatResponse>, Status> {
+        Ok(Response::new(HeartbeatResponse { next_interval_ms: 30_000 }))
+    }
+}
+
+#[tonic::async_trait]
+impl DesiredStateService for ControllerSvc {
+    async fn pull(&self, _req: Request<DesiredStateRequest>) -> Result<Response<DesiredStateUpdate>, Status> {
+        Ok(Response::new(DesiredStateUpdate { version: String::new(), configs: vec![] }))
+    }
+}
+
+#[tonic::async_trait]
+impl PlanService for ControllerSvc {
+    async fn apply(&self, req: Request<ApplyPlanRequest>) -> Result<Response<ApplyPlanResult>, Status> {
+        let plan_id = req.into_inner().plan_id;
+        Ok(Response::new(ApplyPlanResult { plan_id, success: true, message: String::new(), details_json: String::new() }))
+    }
+}
+
+#[tonic::async_trait]
+impl LogService for ControllerSvc {
+    async fn stream(&self, mut req: Request<tonic::Streaming<LogEnvelope>>) -> Result<Response<StreamAck>, Status> {
+        let mut last_seq = 0u64;
+        while let Some(_env) = req.get_mut().message().await.transpose()? {
+            last_seq += 1;
+        }
+        Ok(Response::new(StreamAck { ack_seq: last_seq }))
+    }
+}
+
+pub async fn serve_grpc(
+    addr: std::net::SocketAddr,
+    tls_identity: Identity,
+    client_ca: Certificate,
+    db: Pool<Postgres>,
+) -> Result<()> {
+    let svc = ControllerSvc { db };
+
+    Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(tls_identity).client_ca_root(client_ca))?
+        .add_service(EnrollmentServiceServer::new(svc.clone()))
+        .add_service(HeartbeatServiceServer::new(svc.clone()))
+        .add_service(DesiredStateServiceServer::new(svc.clone()))
+        .add_service(PlanServiceServer::new(svc.clone()))
+        .add_service(LogServiceServer::new(svc))
+        .serve(addr)
+        .await?;
+    Ok(())
+}
+

--- a/crates/controller/src/main.rs
+++ b/crates/controller/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod db;
 mod tls;
 mod server;
+mod grpc;
 
 use anyhow::Result;
 use tokio::net::TcpListener;
@@ -16,28 +17,35 @@ async fn main() -> Result<()> {
         .init();
 
     let cfg = config::Config::from_env()?;
-    let _pool = db::connect(&cfg.database_url).await?;
+    let pool = db::connect(&cfg.database_url).await?;
+    db::migrate(&pool).await?;
 
-    let tls_cfg = tls::server_config(&cfg.tls_cert_path, &cfg.tls_key_path, &cfg.client_ca_path)?;
-    let acceptor = TlsAcceptor::from(std::sync::Arc::new(tls_cfg));
+    // gRPC server (mTLS)
+    let grpc_addr: std::net::SocketAddr = cfg.grpc_bind_addr.parse()?;
+    let identity = tls::tonic_server_identity(&cfg.tls_cert_path, &cfg.tls_key_path)?;
+    let client_ca = tls::tonic_client_ca(&cfg.client_ca_path)?;
 
-    let listener = TcpListener::bind(&cfg.bind_addr).await?;
-    tracing::info!(addr = %cfg.bind_addr, "controller listening (mTLS)");
+    // Optionally keep a small HTTPS /healthz server on a separate port
+    let http_bind = cfg.bind_addr.clone();
+    tokio::spawn(async move {
+        match serve_health(http_bind).await {
+            Ok(()) => {}
+            Err(e) => tracing::warn!(error = ?e, "health server failed"),
+        }
+    });
 
+    tracing::info!(addr = %cfg.grpc_bind_addr, "gRPC listening (mTLS)");
+    grpc::serve_grpc(grpc_addr, identity, client_ca, pool).await?;
+    Ok(())
+}
+
+async fn serve_health(bind_addr: String) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(&bind_addr).await?;
     let app = server::app();
-
     loop {
         let (stream, _) = listener.accept().await?;
-        let acceptor = acceptor.clone();
         let app = app.clone();
         tokio::spawn(async move {
-            let stream = match acceptor.accept(stream).await {
-                Ok(s) => s,
-                Err(err) => {
-                    tracing::warn!(?err, "TLS accept failed");
-                    return;
-                }
-            };
             if let Err(err) = axum::serve(stream, app).await {
                 tracing::warn!(?err, "serve error");
             }

--- a/crates/controller/src/tls.rs
+++ b/crates/controller/src/tls.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Result};
-use rustls::{ServerConfig, ServerConnection, SupportedCipherSuite, Certificate};
+use rustls::{ServerConfig, Certificate};
 use rustls::{RootCertStore, ServerConfig as _};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::fs::File;
 use std::io::BufReader;
+use tonic::transport::{Identity as TonicIdentity, Certificate as TonicCertificate};
 
 pub fn server_config(
     cert_path: &str,
@@ -49,4 +50,17 @@ fn load_client_ca(path: &str) -> Result<std::sync::Arc<rustls::server::WebPkiCli
     }
     let verifier = rustls::server::WebPkiClientVerifier::builder(store).build()?;
     Ok(std::sync::Arc::new(verifier))
+}
+
+pub fn tonic_server_identity(cert_path: &str, key_path: &str) -> Result<TonicIdentity> {
+    use std::fs;
+    let cert = fs::read(cert_path)?;
+    let key = fs::read(key_path)?;
+    Ok(TonicIdentity::from_pem(cert, key))
+}
+
+pub fn tonic_client_ca(client_ca_path: &str) -> Result<TonicCertificate> {
+    use std::fs;
+    let ca = fs::read(client_ca_path)?;
+    Ok(TonicCertificate::from_pem(ca))
 }

--- a/docs/plugin_abi.md
+++ b/docs/plugin_abi.md
@@ -1,0 +1,43 @@
+# Plugin ABI (WASM/WASI) — v0 Draft
+
+Goals
+- Safe, capability-limited execution for plugins.
+- Deterministic inputs/outputs with versioned schemas.
+- No ambient network or host filesystem access by default.
+
+Execution
+- WASM runtime: wasmtime with WASI preview2.
+- Resource limits: CPU time (fuel metering), memory cap (e.g., 64MiB), wall-clock deadline.
+- Capabilities: provided per-plugin via hostcalls; default is none.
+
+Exports (from plugin)
+- `validate(input_json: string) -> result_json`
+  - Validate desired config against schema; return errors/warnings.
+- `render(input_json: string) -> artifacts_json`
+  - Produce config artifacts (files/templates) for the target tool.
+- `plan(current_json: string, desired_json: string) -> plan_json`
+  - Compute apply plan (diff, steps, probes, rollbacks).
+- `analyze(event_json: string) -> hints_json`
+  - Consume a single parsed log/event and emit diagnostics/hints.
+
+Hostcalls (provided by controller/agent)
+- `host_log(level: u32, ptr: u32, len: u32)`
+- `host_now_mono_ms() -> u64`
+- `host_scratch_write(path_ptr: u32, path_len: u32, buf_ptr: u32, buf_len: u32) -> i32`
+- `host_scratch_read(path_ptr: u32, path_len: u32, out_ptr: u32, out_len: u32) -> i32`
+
+Validation & Signing
+- Plugins are signed (detached signature over WASM SHA-256). Controller verifies signature + policy before load.
+- Plugin declares metadata: name, version, category, required capabilities, schema versions.
+
+I/O Format
+- JSON canonicalized (UTF-8) for v0; Protobuf/FlatBuffers can be added later.
+- Size limits enforced at host boundary.
+
+Error Handling
+- Functions return JSON with `{ "ok": bool, "errors": [..], "warnings": [..], "data": {..} }`.
+
+Security Considerations
+- No network access by default; no host FS access except scratch dir if enabled.
+- Strict timeouts and memory limits; abort on violation.
+- Inputs validated by host before passing to plugin.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,33 @@
+# Controller–Agent Protocol (v0)
+
+- Transport: HTTP/2 over mTLS (TLS 1.3 only). Client cert required for agent endpoints. Certificates rotate frequently.
+- Encoding: gRPC/Protobuf (proto files in `proto/swap/v1`). JSON examples provided for readability.
+- Identity: Agent identity bound to client certificate; `agent_id` is a UUID assigned at enrollment.
+- Replay/ordering: Each stream uses sequence numbers and monotonic timestamps; server enforces ordering per agent.
+
+## Services
+
+- EnrollmentService.Enroll
+  - Input: CSR + optional bootstrap token + AgentHello.
+  - Output: Signed agent certificate + CA chain + agent_id.
+  - Note: In deployments without bootstrap tokens, enrollment is disabled; use pre-provisioned certs.
+- HeartbeatService.Heartbeat
+  - Input: agent_id, seq, monotonic_ms. Output: next_interval_ms.
+- DesiredStateService.Pull
+  - Input: agent_id, last_version. Output: DesiredStateUpdate (version + plugin configs).
+- PlanService.Apply
+  - Input: agent_id, plugin_id, plan_id, plan_json. Output: result.
+- LogService.Stream
+  - Client-streaming from agent to controller; includes optional Ed25519 signature per envelope.
+
+## Security Notes
+
+- Agents use outbound-only connections to the controller.
+- Certificates are pinned to the controller CA; agents verify the server cert.
+- Optional message-level signatures for logs to defend if TLS is terminated by middleboxes.
+- Backoff with jitter; idempotent operations and resumable streams.
+
+## Next
+
+- Add SPIFFE/SPIRE integration for workload identities.
+- Add TPM-backed key support on agents for CSR signing.

--- a/migrations/0002_events.sql
+++ b/migrations/0002_events.sql
@@ -1,0 +1,18 @@
+-- events / logs storage (minimal v0)
+CREATE TABLE IF NOT EXISTS events (
+    id BIGSERIAL PRIMARY KEY,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    source TEXT NOT NULL,           -- e.g., journald, apparmor, falco
+    level TEXT NOT NULL,            -- info|warn|error|debug
+    message TEXT NOT NULL,
+    details JSONB,                  -- parsed structured fields
+    seq BIGINT,                     -- optional per-agent sequence
+    signature BYTEA                 -- optional Ed25519 signature
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events (agent_id);
+CREATE INDEX IF NOT EXISTS idx_events_source ON events (source);
+CREATE INDEX IF NOT EXISTS idx_events_level ON events (level);
+CREATE INDEX IF NOT EXISTS idx_events_details_gin ON events USING GIN (details);

--- a/proto/swap/v1/controller_agent.proto
+++ b/proto/swap/v1/controller_agent.proto
@@ -1,0 +1,110 @@
+syntax = "proto3";
+
+package swap.v1;
+
+// Basic types
+message Empty {}
+
+message Label {
+  string key = 1;
+  string value = 2;
+}
+
+message AgentHello {
+  string hostname = 1;
+  string os = 2;           // e.g., linux
+  string arch = 3;         // e.g., x86_64, aarch64
+  string version = 4;      // agent version
+  repeated Label labels = 5;
+}
+
+message EnrollmentRequest {
+  // Optional bootstrap token for first-time CSR exchange; may be empty if pre-provisioned.
+  string bootstrap_token = 1;
+  bytes csr = 2; // PKCS#10 CSR for agent mTLS cert
+  AgentHello hello = 3;
+}
+
+message EnrollmentResponse {
+  string agent_id = 1; // UUID
+  bytes certificate = 2; // DER-encoded cert
+  bytes ca_chain = 3;   // DER-encoded chain
+}
+
+message HeartbeatRequest {
+  string agent_id = 1;
+  uint64 seq = 2;
+  uint64 monotonic_ms = 3;
+}
+
+message HeartbeatResponse {
+  uint64 next_interval_ms = 1;
+}
+
+message DesiredStateRequest {
+  string agent_id = 1;
+  // last state version the agent has; empty for first fetch
+  string last_version = 2;
+}
+
+message DesiredStateUpdate {
+  string version = 1; // monotonically increasing state version
+  // Per-plugin desired configs; schema defined per plugin.
+  message PluginConfig {
+    string plugin_id = 1; // UUID
+    string config_id = 2; // UUID
+    string schema_version = 3;
+    string config_json = 4; // JSON string; use JSON canonicalization on wire
+  }
+  repeated PluginConfig configs = 2;
+}
+
+message ApplyPlanRequest {
+  string agent_id = 1;
+  string plugin_id = 2;
+  string plan_id = 3;      // UUID
+  string plan_json = 4;    // Rendered plan (steps, files, commands, probes)
+}
+
+message ApplyPlanResult {
+  string plan_id = 1;
+  bool success = 2;
+  string message = 3;
+  string details_json = 4; // Optional structured details
+}
+
+message LogEnvelope {
+  string agent_id = 1;
+  uint64 seq = 2;               // sequence per stream
+  string source = 3;            // e.g., journald, apparmor, falco
+  string level = 4;             // info|warn|error|debug
+  int64 ts_unix_ms = 5;
+  string message = 6;
+  string details_json = 7;      // parsed fields
+  bytes signature = 8;          // optional Ed25519 signature
+}
+
+message StreamAck {
+  uint64 ack_seq = 1;
+}
+
+service EnrollmentService {
+  rpc Enroll(EnrollmentRequest) returns (EnrollmentResponse);
+}
+
+service HeartbeatService {
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+}
+
+service DesiredStateService {
+  rpc Pull(DesiredStateRequest) returns (DesiredStateUpdate);
+}
+
+service PlanService {
+  rpc Apply(ApplyPlanRequest) returns (ApplyPlanResult);
+}
+
+service LogService {
+  rpc Stream(stream LogEnvelope) returns (StreamAck);
+}
+


### PR DESCRIPTION
# SPEC: Controller gRPC/mTLS Skeleton and DB Migrations

## Goals
- Establish the controller’s gRPC surface over HTTP/2 with strict mTLS.
- Provide a portable migration strategy applied at startup with idempotent, additive changes.
- Provide an agent bootstrap client path (heartbeat) validating connectivity and TLS policy.

## Non‑Goals (v0)
- Finalized enrollment logic and cert issuance workflows (specified, to be implemented next).
- Health/metrics endpoints beyond a minimal health check.

## Networking & Ports
- gRPC: 10443/TCP (HTTP/2 only, TLS 1.3, client cert required for agent endpoints).
- Healthz: 10445/TCP minimal HTTP responder (non-sensitive). In production this can be a loopback-only readiness probe.

```mermaid
flowchart LR
  subgraph Host
    C[Controller gRPC :10443 mTLS]\nHealthz :10445
  end
  Agent -->|mTLS h2| C
```

## TLS/mTLS Policy
- Protocol: TLS 1.3 only. ALPN: h2.
- Server presents controller certificate. Agents present client certificate issued by controller CA (or pre-provisioned CA in hardened deployments).
- Cipher suites: modern AEAD (AES-256-GCM or CHACHA20-POLY1305). No renegotiation.
- Certificate rotation: controller will support rotation without downtime in a later iteration; currently restart is acceptable.

```mermaid
sequenceDiagram
  participant A as Agent
  participant C as Controller (gRPC)
  A->>C: TLS handshake (client cert auth)
  C-->>A: ALPN=h2, TLS1.3
  A->>C: Heartbeat(agent_id, seq, mono_ms)
  C-->>A: next_interval_ms
```

## Services (Stubbed)
- EnrollmentService.Enroll: CSR/token exchange. To be implemented with policy checks and issuance.
- HeartbeatService.Heartbeat: liveness and interval hints.
- DesiredStateService.Pull: versioned config delivery per plugin.
- PlanService.Apply: apply result reporting.
- LogService.Stream: client-streaming logs with ack.

## Database Migrations
- Applied at startup via a migration runner.
- Strictly additive; no altering past migration files.
- PostgreSQL features: citext, jsonb, indexes on timestamps/agent/source.
- Acceptance: migrations run successfully on empty and existing DBs.

## Observability & Limits
- Request timeouts and body size limits to be enforced at transport layer in next iteration.
- Tracing via structured logs; metrics endpoint candidate in future PR.

## Security Considerations
- Mutual TLS with pinned controller CA; no passwords for agents.
- Rate limiting plan: per-agent and per-IP to mitigate abuse; to be added with tower layers.
- Authorization: agent identity derived from client cert and bound to `agent_id`.

## Acceptance Criteria
- Controller listens on 10443 (gRPC mTLS) and responds to Heartbeat.
- Migrations run at startup successfully.
- Healthz endpoint responds over 10445.
- No proxy employed; direct Rust TLS stack only.
