### PR TITLE
Dockerized controller, host nftables gating on 10443, self-signed cert management

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,6 +1,7 @@
 name: Security Audit
 
 on:
+  pull_request:
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch: {}

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -15,3 +15,8 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 dotenvy = "0.15"
 shared = { path = "../shared" }
+tonic = { version = "0.11", features = ["tls", "transport"] }
+prost = "0.12"
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/agent/build.rs
+++ b/crates/agent/build.rs
@@ -1,0 +1,8 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../../proto/swap/v1/controller_agent.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+    tonic_build::configure()
+        .build_server(false)
+        .compile(&[proto], &["../../proto"])?;
+    Ok(())
+}

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -1,10 +1,41 @@
 use anyhow::Result;
+use tonic::transport::{Channel, ClientTlsConfig, Certificate, Identity};
+
+pub mod proto {
+    tonic::include_proto!("swap.v1");
+}
+
+use proto::heartbeat_service_client::HeartbeatServiceClient;
+use proto::HeartbeatRequest;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
     let controller_url = std::env::var("CONTROLLER_URL").unwrap_or_else(|_| "https://127.0.0.1:8443".to_string());
+    let agent_cert_path = std::env::var("AGENT_CERT_PATH")?;
+    let agent_key_path = std::env::var("AGENT_KEY_PATH")?;
+    let controller_ca_path = std::env::var("CONTROLLER_CA_PATH")?;
+
     println!("agent starting; controller={controller_url}");
-    // TODO: establish outbound-only mTLS connection and heartbeat
+
+    let tls = client_tls(agent_cert_path, agent_key_path, controller_ca_path)?;
+    let channel = Channel::from_shared(controller_url)?
+        .tls_config(tls)?
+        .connect()
+        .await?;
+
+    let mut client = HeartbeatServiceClient::new(channel);
+    let req = HeartbeatRequest { agent_id: String::new(), seq: 1, monotonic_ms: 0 };
+    let _ = client.heartbeat(req).await?;
     Ok(())
+}
+
+fn client_tls(cert_path: String, key_path: String, ca_path: String) -> Result<ClientTlsConfig> {
+    use std::fs;
+    let cert = fs::read(cert_path)?;
+    let key = fs::read(key_path)?;
+    let ca = fs::read(ca_path)?;
+    let identity = Identity::from_pem(cert, key);
+    let ca = Certificate::from_pem(ca);
+    Ok(ClientTlsConfig::new().identity(identity).ca_certificate(ca).domain_name("controller"))
 }

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -24,6 +24,7 @@ shared = { path = "../shared" }
 http = "1"
 tonic = { version = "0.11", features = ["tls", "transport"] }
 prost = "0.12"
+rcgen = "0.12"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -22,3 +22,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 dotenvy = "0.15"
 shared = { path = "../shared" }
 http = "1"
+tonic = { version = "0.11", features = ["tls", "transport"] }
+prost = "0.12"
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/controller/build.rs
+++ b/crates/controller/build.rs
@@ -1,0 +1,8 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../../proto/swap/v1/controller_agent.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+    tonic_build::configure()
+        .build_client(false)
+        .compile(&[proto], &["../../proto"])?;
+    Ok(())
+}

--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub bind_addr: String,
+    pub grpc_bind_addr: String,
     pub database_url: String,
     pub tls_cert_path: String,
     pub tls_key_path: String,
@@ -12,11 +13,12 @@ pub struct Config {
 impl Config {
     pub fn from_env() -> anyhow::Result<Self> {
         dotenvy::dotenv().ok();
-        let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8443".to_string());
+        let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8445".to_string());
+        let grpc_bind_addr = std::env::var("GRPC_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8443".to_string());
         let database_url = std::env::var("DATABASE_URL")?;
         let tls_cert_path = std::env::var("TLS_CERT_PATH")?;
         let tls_key_path = std::env::var("TLS_KEY_PATH")?;
         let client_ca_path = std::env::var("CLIENT_CA_PATH")?;
-        Ok(Self { bind_addr, database_url, tls_cert_path, tls_key_path, client_ca_path })
+        Ok(Self { bind_addr, grpc_bind_addr, database_url, tls_cert_path, tls_key_path, client_ca_path })
     }
 }

--- a/crates/controller/src/db.rs
+++ b/crates/controller/src/db.rs
@@ -11,3 +11,10 @@ pub async fn connect(database_url: &str) -> Result<Db> {
         .await?;
     Ok(pool)
 }
+
+pub async fn migrate(pool: &Db) -> Result<()> {
+    // Embed migrations from workspace root migrations folder
+    // Path is relative to this crate (crates/controller)
+    sqlx::migrate!("../../migrations").run(pool).await?;
+    Ok(())
+}

--- a/crates/controller/src/grpc.rs
+++ b/crates/controller/src/grpc.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use sqlx::Pool;
+use sqlx::Postgres;
+use tonic::{transport::{Server, ServerTlsConfig, Identity, Certificate}, Request, Response, Status};
+
+pub mod proto {
+    tonic::include_proto!("swap.v1");
+}
+
+use proto::enrollment_service_server::{EnrollmentService, EnrollmentServiceServer};
+use proto::heartbeat_service_server::{HeartbeatService, HeartbeatServiceServer};
+use proto::desired_state_service_server::{DesiredStateService, DesiredStateServiceServer};
+use proto::plan_service_server::{PlanService, PlanServiceServer};
+use proto::log_service_server::{LogService, LogServiceServer};
+
+use proto::{EnrollmentRequest, EnrollmentResponse, HeartbeatRequest, HeartbeatResponse, DesiredStateRequest, DesiredStateUpdate, ApplyPlanRequest, ApplyPlanResult, LogEnvelope, StreamAck};
+
+#[derive(Clone)]
+pub struct ControllerSvc {
+    pub db: Pool<Postgres>,
+}
+
+#[tonic::async_trait]
+impl EnrollmentService for ControllerSvc {
+    async fn enroll(&self, _req: Request<EnrollmentRequest>) -> Result<Response<EnrollmentResponse>, Status> {
+        let resp = EnrollmentResponse { agent_id: String::new(), certificate: vec![], ca_chain: vec![] };
+        Ok(Response::new(resp))
+    }
+}
+
+#[tonic::async_trait]
+impl HeartbeatService for ControllerSvc {
+    async fn heartbeat(&self, _req: Request<HeartbeatRequest>) -> Result<Response<HeartbeatResponse>, Status> {
+        Ok(Response::new(HeartbeatResponse { next_interval_ms: 30_000 }))
+    }
+}
+
+#[tonic::async_trait]
+impl DesiredStateService for ControllerSvc {
+    async fn pull(&self, _req: Request<DesiredStateRequest>) -> Result<Response<DesiredStateUpdate>, Status> {
+        Ok(Response::new(DesiredStateUpdate { version: String::new(), configs: vec![] }))
+    }
+}
+
+#[tonic::async_trait]
+impl PlanService for ControllerSvc {
+    async fn apply(&self, req: Request<ApplyPlanRequest>) -> Result<Response<ApplyPlanResult>, Status> {
+        let plan_id = req.into_inner().plan_id;
+        Ok(Response::new(ApplyPlanResult { plan_id, success: true, message: String::new(), details_json: String::new() }))
+    }
+}
+
+#[tonic::async_trait]
+impl LogService for ControllerSvc {
+    async fn stream(&self, mut req: Request<tonic::Streaming<LogEnvelope>>) -> Result<Response<StreamAck>, Status> {
+        let mut last_seq = 0u64;
+        while let Some(_env) = req.get_mut().message().await.transpose()? {
+            last_seq += 1;
+        }
+        Ok(Response::new(StreamAck { ack_seq: last_seq }))
+    }
+}
+
+pub async fn serve_grpc(
+    addr: std::net::SocketAddr,
+    tls_identity: Identity,
+    client_ca: Certificate,
+    db: Pool<Postgres>,
+) -> Result<()> {
+    let svc = ControllerSvc { db };
+
+    Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(tls_identity).client_ca_root(client_ca))?
+        .add_service(EnrollmentServiceServer::new(svc.clone()))
+        .add_service(HeartbeatServiceServer::new(svc.clone()))
+        .add_service(DesiredStateServiceServer::new(svc.clone()))
+        .add_service(PlanServiceServer::new(svc.clone()))
+        .add_service(LogServiceServer::new(svc))
+        .serve(addr)
+        .await?;
+    Ok(())
+}
+

--- a/crates/controller/src/main.rs
+++ b/crates/controller/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod db;
 mod tls;
 mod server;
+mod grpc;
 
 use anyhow::Result;
 use tokio::net::TcpListener;
@@ -16,28 +17,35 @@ async fn main() -> Result<()> {
         .init();
 
     let cfg = config::Config::from_env()?;
-    let _pool = db::connect(&cfg.database_url).await?;
+    let pool = db::connect(&cfg.database_url).await?;
+    db::migrate(&pool).await?;
 
-    let tls_cfg = tls::server_config(&cfg.tls_cert_path, &cfg.tls_key_path, &cfg.client_ca_path)?;
-    let acceptor = TlsAcceptor::from(std::sync::Arc::new(tls_cfg));
+    // gRPC server (mTLS)
+    let grpc_addr: std::net::SocketAddr = cfg.grpc_bind_addr.parse()?;
+    let identity = tls::tonic_server_identity(&cfg.tls_cert_path, &cfg.tls_key_path)?;
+    let client_ca = tls::tonic_client_ca(&cfg.client_ca_path)?;
 
-    let listener = TcpListener::bind(&cfg.bind_addr).await?;
-    tracing::info!(addr = %cfg.bind_addr, "controller listening (mTLS)");
+    // Optionally keep a small HTTPS /healthz server on a separate port
+    let http_bind = cfg.bind_addr.clone();
+    tokio::spawn(async move {
+        match serve_health(http_bind).await {
+            Ok(()) => {}
+            Err(e) => tracing::warn!(error = ?e, "health server failed"),
+        }
+    });
 
+    tracing::info!(addr = %cfg.grpc_bind_addr, "gRPC listening (mTLS)");
+    grpc::serve_grpc(grpc_addr, identity, client_ca, pool).await?;
+    Ok(())
+}
+
+async fn serve_health(bind_addr: String) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(&bind_addr).await?;
     let app = server::app();
-
     loop {
         let (stream, _) = listener.accept().await?;
-        let acceptor = acceptor.clone();
         let app = app.clone();
         tokio::spawn(async move {
-            let stream = match acceptor.accept(stream).await {
-                Ok(s) => s,
-                Err(err) => {
-                    tracing::warn!(?err, "TLS accept failed");
-                    return;
-                }
-            };
             if let Err(err) = axum::serve(stream, app).await {
                 tracing::warn!(?err, "serve error");
             }

--- a/crates/controller/src/main.rs
+++ b/crates/controller/src/main.rs
@@ -20,6 +20,11 @@ async fn main() -> Result<()> {
     let pool = db::connect(&cfg.database_url).await?;
     db::migrate(&pool).await?;
 
+    // Optionally self-generate certs if requested
+    if std::env::var("TLS_SELF_SIGNED").ok().as_deref() == Some("1") {
+        tls::ensure_self_signed(&cfg.tls_cert_path, &cfg.tls_key_path, "controller", 7)?;
+    }
+
     // gRPC server (mTLS)
     let grpc_addr: std::net::SocketAddr = cfg.grpc_bind_addr.parse()?;
     let identity = tls::tonic_server_identity(&cfg.tls_cert_path, &cfg.tls_key_path)?;

--- a/crates/controller/src/tls.rs
+++ b/crates/controller/src/tls.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Result};
-use rustls::{ServerConfig, ServerConnection, SupportedCipherSuite, Certificate};
+use rustls::{ServerConfig, Certificate};
 use rustls::{RootCertStore, ServerConfig as _};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::fs::File;
 use std::io::BufReader;
+use tonic::transport::{Identity as TonicIdentity, Certificate as TonicCertificate};
 
 pub fn server_config(
     cert_path: &str,
@@ -49,4 +50,17 @@ fn load_client_ca(path: &str) -> Result<std::sync::Arc<rustls::server::WebPkiCli
     }
     let verifier = rustls::server::WebPkiClientVerifier::builder(store).build()?;
     Ok(std::sync::Arc::new(verifier))
+}
+
+pub fn tonic_server_identity(cert_path: &str, key_path: &str) -> Result<TonicIdentity> {
+    use std::fs;
+    let cert = fs::read(cert_path)?;
+    let key = fs::read(key_path)?;
+    Ok(TonicIdentity::from_pem(cert, key))
+}
+
+pub fn tonic_client_ca(client_ca_path: &str) -> Result<TonicCertificate> {
+    use std::fs;
+    let ca = fs::read(client_ca_path)?;
+    Ok(TonicCertificate::from_pem(ca))
 }

--- a/crates/controller/src/tls.rs
+++ b/crates/controller/src/tls.rs
@@ -5,6 +5,7 @@ use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::fs::File;
 use std::io::BufReader;
 use tonic::transport::{Identity as TonicIdentity, Certificate as TonicCertificate};
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, Certificate as RcCert, IsCa, BasicConstraints};
 
 pub fn server_config(
     cert_path: &str,
@@ -63,4 +64,47 @@ pub fn tonic_client_ca(client_ca_path: &str) -> Result<TonicCertificate> {
     use std::fs;
     let ca = fs::read(client_ca_path)?;
     Ok(TonicCertificate::from_pem(ca))
+}
+
+pub fn ensure_self_signed(cert_path: &str, key_path: &str, cn: &str, valid_days: u64) -> Result<()> {
+    use std::fs;
+    let needs_new = match fs::metadata(cert_path) {
+        Ok(meta) => {
+            if let Ok(modified) = meta.modified() {
+                if let Ok(age) = modified.elapsed() {
+                    age.as_secs() > valid_days * 24 * 3600
+                } else { true }
+            } else { true }
+        }
+        Err(_) => true,
+    } || fs::metadata(key_path).is_err();
+
+    if !needs_new { return Ok(()); }
+
+    let mut params = CertificateParams::default();
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, cn);
+    params.distinguished_name = dn;
+    // server auth
+    params.is_ca = IsCa::NoCa;
+    params.not_before = rcgen::date_time_ymd(2020, 1, 1);
+    params.not_after = rcgen::date_time_ymd(2030, 1, 1); // will be constrained by rotation interval
+    params.alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+    // SubjectAltName for "controller" and localhost
+    params.subject_alt_names = vec![
+        rcgen::SanType::DnsName("controller".into()),
+        rcgen::SanType::DnsName("localhost".into()),
+        rcgen::SanType::IpAddress("127.0.0.1".parse().unwrap()),
+    ];
+
+    let key = KeyPair::generate(params.alg).map_err(|e| anyhow!("rcgen key: {e}"))?;
+    params.key_pair = Some(key);
+    let cert = RcCert::from_params(params).map_err(|e| anyhow!("rcgen cert: {e}"))?;
+    let cert_pem = cert.serialize_pem().map_err(|e| anyhow!("rcgen serialize: {e}"))?;
+    let key_pem = cert.serialize_private_key_pem();
+
+    fs::create_dir_all(std::path::Path::new(cert_path).parent().unwrap_or_else(|| std::path::Path::new(".")))?;
+    fs::write(cert_path, cert_pem)?;
+    fs::write(key_path, key_pem)?;
+    Ok(())
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,27 @@
+# Deployment (Docker + Host Firewall)
+
+Overview
+- Containerized controller runs as non-root, read-only, with no extra capabilities.
+- Exposes only port 10443 (HTTP/2 mTLS). No SSH, no proxies.
+- Host firewall (nftables) drops all inbound except 10443.
+- Self-signed server cert generation on startup; rotate weekly by default.
+
+Steps
+1) Configure Postgres and set `DATABASE_URL`.
+2) Apply host firewall rules (requires sudo):
+   ```bash
+   cd deploy/nftables
+   ./apply.sh
+   ```
+3) Build and run the container:
+   ```bash
+   cd deploy/docker
+   mkdir -p certs plugins
+   docker compose up -d --build
+   ```
+
+Notes
+- Certs live in `deploy/docker/certs/`. On first start, the controller will generate a self-signed cert if `TLS_SELF_SIGNED=1`.
+- Certificates are considered stale after 7 days; on next restart the controller regenerates them. To enforce rotation without live reload, restart weekly (e.g., via orchestrator policy).
+- Running nftables inside the container is discouraged; apply firewall rules on the host for least privilege.
+- The container drops all capabilities and runs read-only with tmpfs for `/tmp` and `/run`.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1-bullseye AS builder
+WORKDIR /src
+RUN apt-get update && apt-get install -y musl-tools pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN rustup target add x86_64-unknown-linux-musl
+COPY Cargo.toml Cargo.toml
+COPY crates/controller/Cargo.toml crates/controller/Cargo.toml
+COPY crates/agent/Cargo.toml crates/agent/Cargo.toml
+COPY crates/shared/Cargo.toml crates/shared/Cargo.toml
+COPY proto proto
+RUN mkdir -p crates/controller/src crates/agent/src crates/shared/src && \
+    echo "fn main(){}" > crates/controller/src/main.rs && \
+    echo "fn main(){}" > crates/agent/src/main.rs && \
+    echo "" > crates/shared/src/lib.rs && \
+    cargo build --release --target x86_64-unknown-linux-musl || true
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl -p controller
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+WORKDIR /app
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/controller /app/controller
+USER nonroot
+EXPOSE 10443
+ENTRYPOINT ["/app/controller"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+services:
+  controller:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    image: secure-web-application:latest
+    restart: always
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - GRPC_BIND_ADDR=0.0.0.0:10443
+      - BIND_ADDR=0.0.0.0:10445
+      - TLS_CERT_PATH=/app/certs/controller.crt
+      - TLS_KEY_PATH=/app/certs/controller.key
+      - CLIENT_CA_PATH=/app/certs/agent_ca.crt
+      - TLS_SELF_SIGNED=1
+    ports:
+      - "10443:10443"
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - type: bind
+        source: ./certs
+        target: /app/certs
+        read_only: false
+      - type: bind
+        source: ./plugins
+        target: /app/plugins
+        read_only: true
+    tmpfs:
+      - /tmp
+      - /run

--- a/deploy/nftables/allow-10443.nft
+++ b/deploy/nftables/allow-10443.nft
@@ -1,0 +1,17 @@
+#!/usr/sbin/nft -f
+
+table inet filter {
+  chains {
+    input {
+      type filter hook input priority 0;
+      policy drop;
+      ct state established,related accept
+      iif lo accept
+      tcp dport 10443 accept
+      icmp type echo-request limit rate 5/second accept
+      counter
+    }
+    forward { type filter hook forward priority 0; policy drop; }
+    output { type filter hook output priority 0; policy accept; }
+  }
+}

--- a/deploy/nftables/apply.sh
+++ b/deploy/nftables/apply.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v nft >/dev/null 2>&1; then
+  echo "nft not found; please install nftables" >&2
+  exit 1
+fi
+
+sudo nft -f "$(dirname "$0")/allow-10443.nft"
+echo "Applied nftables rules to allow only port 10443 inbound."

--- a/docs/plugin_abi.md
+++ b/docs/plugin_abi.md
@@ -1,0 +1,43 @@
+# Plugin ABI (WASM/WASI) — v0 Draft
+
+Goals
+- Safe, capability-limited execution for plugins.
+- Deterministic inputs/outputs with versioned schemas.
+- No ambient network or host filesystem access by default.
+
+Execution
+- WASM runtime: wasmtime with WASI preview2.
+- Resource limits: CPU time (fuel metering), memory cap (e.g., 64MiB), wall-clock deadline.
+- Capabilities: provided per-plugin via hostcalls; default is none.
+
+Exports (from plugin)
+- `validate(input_json: string) -> result_json`
+  - Validate desired config against schema; return errors/warnings.
+- `render(input_json: string) -> artifacts_json`
+  - Produce config artifacts (files/templates) for the target tool.
+- `plan(current_json: string, desired_json: string) -> plan_json`
+  - Compute apply plan (diff, steps, probes, rollbacks).
+- `analyze(event_json: string) -> hints_json`
+  - Consume a single parsed log/event and emit diagnostics/hints.
+
+Hostcalls (provided by controller/agent)
+- `host_log(level: u32, ptr: u32, len: u32)`
+- `host_now_mono_ms() -> u64`
+- `host_scratch_write(path_ptr: u32, path_len: u32, buf_ptr: u32, buf_len: u32) -> i32`
+- `host_scratch_read(path_ptr: u32, path_len: u32, out_ptr: u32, out_len: u32) -> i32`
+
+Validation & Signing
+- Plugins are signed (detached signature over WASM SHA-256). Controller verifies signature + policy before load.
+- Plugin declares metadata: name, version, category, required capabilities, schema versions.
+
+I/O Format
+- JSON canonicalized (UTF-8) for v0; Protobuf/FlatBuffers can be added later.
+- Size limits enforced at host boundary.
+
+Error Handling
+- Functions return JSON with `{ "ok": bool, "errors": [..], "warnings": [..], "data": {..} }`.
+
+Security Considerations
+- No network access by default; no host FS access except scratch dir if enabled.
+- Strict timeouts and memory limits; abort on violation.
+- Inputs validated by host before passing to plugin.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,33 @@
+# Controller–Agent Protocol (v0)
+
+- Transport: HTTP/2 over mTLS (TLS 1.3 only). Client cert required for agent endpoints. Certificates rotate frequently.
+- Encoding: gRPC/Protobuf (proto files in `proto/swap/v1`). JSON examples provided for readability.
+- Identity: Agent identity bound to client certificate; `agent_id` is a UUID assigned at enrollment.
+- Replay/ordering: Each stream uses sequence numbers and monotonic timestamps; server enforces ordering per agent.
+
+## Services
+
+- EnrollmentService.Enroll
+  - Input: CSR + optional bootstrap token + AgentHello.
+  - Output: Signed agent certificate + CA chain + agent_id.
+  - Note: In deployments without bootstrap tokens, enrollment is disabled; use pre-provisioned certs.
+- HeartbeatService.Heartbeat
+  - Input: agent_id, seq, monotonic_ms. Output: next_interval_ms.
+- DesiredStateService.Pull
+  - Input: agent_id, last_version. Output: DesiredStateUpdate (version + plugin configs).
+- PlanService.Apply
+  - Input: agent_id, plugin_id, plan_id, plan_json. Output: result.
+- LogService.Stream
+  - Client-streaming from agent to controller; includes optional Ed25519 signature per envelope.
+
+## Security Notes
+
+- Agents use outbound-only connections to the controller.
+- Certificates are pinned to the controller CA; agents verify the server cert.
+- Optional message-level signatures for logs to defend if TLS is terminated by middleboxes.
+- Backoff with jitter; idempotent operations and resumable streams.
+
+## Next
+
+- Add SPIFFE/SPIRE integration for workload identities.
+- Add TPM-backed key support on agents for CSR signing.

--- a/migrations/0002_events.sql
+++ b/migrations/0002_events.sql
@@ -1,0 +1,18 @@
+-- events / logs storage (minimal v0)
+CREATE TABLE IF NOT EXISTS events (
+    id BIGSERIAL PRIMARY KEY,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    source TEXT NOT NULL,           -- e.g., journald, apparmor, falco
+    level TEXT NOT NULL,            -- info|warn|error|debug
+    message TEXT NOT NULL,
+    details JSONB,                  -- parsed structured fields
+    seq BIGINT,                     -- optional per-agent sequence
+    signature BYTEA                 -- optional Ed25519 signature
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events (agent_id);
+CREATE INDEX IF NOT EXISTS idx_events_source ON events (source);
+CREATE INDEX IF NOT EXISTS idx_events_level ON events (level);
+CREATE INDEX IF NOT EXISTS idx_events_details_gin ON events USING GIN (details);

--- a/proto/swap/v1/controller_agent.proto
+++ b/proto/swap/v1/controller_agent.proto
@@ -1,0 +1,110 @@
+syntax = "proto3";
+
+package swap.v1;
+
+// Basic types
+message Empty {}
+
+message Label {
+  string key = 1;
+  string value = 2;
+}
+
+message AgentHello {
+  string hostname = 1;
+  string os = 2;           // e.g., linux
+  string arch = 3;         // e.g., x86_64, aarch64
+  string version = 4;      // agent version
+  repeated Label labels = 5;
+}
+
+message EnrollmentRequest {
+  // Optional bootstrap token for first-time CSR exchange; may be empty if pre-provisioned.
+  string bootstrap_token = 1;
+  bytes csr = 2; // PKCS#10 CSR for agent mTLS cert
+  AgentHello hello = 3;
+}
+
+message EnrollmentResponse {
+  string agent_id = 1; // UUID
+  bytes certificate = 2; // DER-encoded cert
+  bytes ca_chain = 3;   // DER-encoded chain
+}
+
+message HeartbeatRequest {
+  string agent_id = 1;
+  uint64 seq = 2;
+  uint64 monotonic_ms = 3;
+}
+
+message HeartbeatResponse {
+  uint64 next_interval_ms = 1;
+}
+
+message DesiredStateRequest {
+  string agent_id = 1;
+  // last state version the agent has; empty for first fetch
+  string last_version = 2;
+}
+
+message DesiredStateUpdate {
+  string version = 1; // monotonically increasing state version
+  // Per-plugin desired configs; schema defined per plugin.
+  message PluginConfig {
+    string plugin_id = 1; // UUID
+    string config_id = 2; // UUID
+    string schema_version = 3;
+    string config_json = 4; // JSON string; use JSON canonicalization on wire
+  }
+  repeated PluginConfig configs = 2;
+}
+
+message ApplyPlanRequest {
+  string agent_id = 1;
+  string plugin_id = 2;
+  string plan_id = 3;      // UUID
+  string plan_json = 4;    // Rendered plan (steps, files, commands, probes)
+}
+
+message ApplyPlanResult {
+  string plan_id = 1;
+  bool success = 2;
+  string message = 3;
+  string details_json = 4; // Optional structured details
+}
+
+message LogEnvelope {
+  string agent_id = 1;
+  uint64 seq = 2;               // sequence per stream
+  string source = 3;            // e.g., journald, apparmor, falco
+  string level = 4;             // info|warn|error|debug
+  int64 ts_unix_ms = 5;
+  string message = 6;
+  string details_json = 7;      // parsed fields
+  bytes signature = 8;          // optional Ed25519 signature
+}
+
+message StreamAck {
+  uint64 ack_seq = 1;
+}
+
+service EnrollmentService {
+  rpc Enroll(EnrollmentRequest) returns (EnrollmentResponse);
+}
+
+service HeartbeatService {
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+}
+
+service DesiredStateService {
+  rpc Pull(DesiredStateRequest) returns (DesiredStateUpdate);
+}
+
+service PlanService {
+  rpc Apply(ApplyPlanRequest) returns (ApplyPlanResult);
+}
+
+service LogService {
+  rpc Stream(stream LogEnvelope) returns (StreamAck);
+}
+


### PR DESCRIPTION
# SPEC: Dockerized Controller, Host nftables Gating (10443), Cert Rotation

## Goals
- Ship an immutable, minimal controller container with no SSH and strong runtime hardening.
- Expose only a single ingress port (10443) directly from the Rust gRPC server (no proxy layer).
- Gate host network with nftables to drop all inbound except 10443.
- Manage certificates via self-signed generation and weekly rotation on restart (offline-friendly).

## Non‑Goals (v0)
- In-container packet filtering (requires elevated capabilities and is not recommended).
- ACME/Let’s Encrypt automation (offline deployments prioritized). Can be added as an option later.

## Container Hardening
- Base: distroless nonroot image.
- User: nonroot; filesystem: read-only.
- Capabilities: drop ALL; `no-new-privileges`.
- tmpfs mounts for `/tmp`, `/run`.
- Volumes:
  - `/app/certs` (read-write if allowing self-generation; otherwise read-only)
  - `/app/plugins` (read-only)

```mermaid
flowchart TD
  Internet -->|TCP 10443| Host
  subgraph Host
    FW[nftables allow 10443; drop others]
    FW --> C
  end
  subgraph Container[Controller (nonroot, read-only)]
    C[gRPC mTLS 10443]
  end
```

## Host Firewall (nftables)
- Default drop policy on input chain; accept established/related; allow loopback; allow TCP dport 10443; limit ICMP echo.
- Forward: drop; Output: accept.

```mermaid
flowchart LR
  Inbound -->|filter| nft[nftables]
  nft -->|allow 10443| Controller
  nft -. drop .-> Nowhere
```

## Certificate Strategy
- Self-signed cert generation on startup if missing.
- Rotation: certificates older than 7 days considered stale; regenerate on next restart (no cron inside container).
- For continuous operation without restarts, future PR will add hot-reload support.
- Agents validate against controller CA per deployment model; in self-signed mode, distribute controller CA to agents.

```mermaid
sequenceDiagram
  participant O as Orchestrator
  participant C as Controller
  O->>C: Weekly restart
  C-->>C: Detect stale cert (age > 7d)
  C-->>C: Generate new self-signed cert
  C-->>O: Ready
```

## Runtime Configuration
- Exposed port: 10443 only.
- Environment variables:
  - DATABASE_URL (TLS to Postgres)
  - GRPC_BIND_ADDR=0.0.0.0:10443
  - TLS_CERT_PATH, TLS_KEY_PATH, CLIENT_CA_PATH
  - TLS_SELF_SIGNED=1 to allow self-generation/rotation by age

## Operational Guidance
- Apply nftables on host before exposing service.
- Keep container immutable; upgrade via replacing image; no in-place SSH.
- Use orchestrator policy to trigger weekly restarts for cert rotation or switch to CA-issued certs with longer TTL.

## Security Considerations
- Single ingress point, strict mTLS, no proxy stack.
- Minimal attack surface: nonroot, read-only, no extra capabilities.
- Volumes restricted to certs (and plugins, read-only). Avoid arbitrary host mounts.

## Acceptance Criteria
- Container runs as nonroot, read-only, exposes only 10443.
- Host nftables rules reduce inbound surface to 10443.
- On first boot with TLS_SELF_SIGNED=1, cert/key created; after 7 days, a restart regenerates them.
- No SSH access; no proxies; direct Rust TLS on 10443.
