### PR TITLE
chore(linear): enforce padded phase/task naming rules

### DIFF
--- a/.claude/skills/sync-github-linear/SKILL.md
+++ b/.claude/skills/sync-github-linear/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: sync-github-linear
+description: Sync GitHub issues and docs markdown to Linear project state using MCP. Use when user asks to keep GitHub and Linear in sync, mirror open/closed status, or refresh roadmap/docs tasks.
+argument-hint: "--owner <owner> --repo <repo> [--project \"SWAP Roadmap\"]"
+disable-model-invocation: false
+allowed-tools: Read, Glob, CallMcpTool
+---
+
+# Sync GitHub and Linear (MCP)
+
+Use this workflow to keep GitHub issues and Linear project items synchronized.
+
+## Scope
+- GitHub roadmap/issues -> Linear issues (create/update/state sync)
+- `docs/**/*.md` -> Linear docs index (refresh when file list changes)
+- Roadmap phases/tasks from `docs/ROADMAP.md` -> Linear phase/task hierarchy
+
+## Canonical Mapping
+- **GitHub issue identity marker** in Linear issue description:
+  - `SYNC_SOURCE: github:<owner>/<repo>#<number>`
+- **Docs file identity marker** in Linear docs index:
+  - file path list + GitHub blob links
+
+Always preserve these markers so updates are idempotent.
+
+## Status Mapping
+- GitHub `OPEN` -> Linear state `Backlog` (or `In Progress` if already active)
+- GitHub `CLOSED` -> Linear state `Done`
+
+## Workflow
+
+1. **Load source state**
+   - `user-github/list_issues` for `OPEN` and `CLOSED` with pagination as needed.
+   - `Glob` for `docs/**/*.md`.
+   - `Read` `docs/ROADMAP.md`.
+
+2. **Ensure target Linear project exists**
+   - `plugin-linear-linear/list_projects` (query by name).
+   - If missing, create with `save_project`.
+
+3. **Ensure phase parents exist**
+   - For each GitHub phase issue (e.g., "Phase 0 ..."), find existing Linear issue in project by marker.
+   - If missing, `create_issue`.
+   - If present, `update_issue` title/description/state.
+
+4. **Ensure roadmap tasks exist and are linked**
+   - Parse numbered tasks in `docs/ROADMAP.md`.
+   - Create/update each as a child issue (`parentId` = phase issue id).
+   - Keep task descriptions linked to relevant spec/plan paths.
+
+5. **Refresh docs index document**
+   - Build markdown list of all docs paths with blob links.
+   - Create or update a Linear document titled `Docs Mirror Index (docs/)`.
+
+6. **State reconciliation**
+   - For each mapped GitHub issue:
+     - OPEN -> `update_issue state=Backlog` (unless actively in progress)
+     - CLOSED -> `update_issue state=Done`
+
+7. **Report**
+   - Return counts:
+     - created/updated/closed Linear issues
+     - created/updated documents
+     - unmatched/missing mapping entries
+
+## Safety Rules
+- Never delete Linear issues/documents automatically.
+- Never change unrelated Linear projects.
+- Keep sync markers in descriptions.
+- Prefer updates over duplicates (idempotent behavior).

--- a/.cursor/rules/linear-naming.mdc
+++ b/.cursor/rules/linear-naming.mdc
@@ -1,0 +1,15 @@
+---
+description: Enforce zero-padded Linear phase and task naming for sort stability
+alwaysApply: true
+---
+
+# Linear Naming Rule
+
+When creating or renaming Linear milestones/issues/tasks, use zero-padded numbering.
+
+- Phase naming: `NN.Phase — <title>`
+  - Example: `01.Phase — Core Security Foundations`
+- Subtask naming: `NN. <title>`
+  - Example: `07. Rate Limits and Backpressure Defaults`
+
+Do not use non-padded forms such as `Phase 1`, `Phase 01`, or `1. <title>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,9 @@ Agent Notes
 - Do not introduce new dependencies casually; justify security impact.
 - Avoid adding license headers or changing licensing unless explicitly requested.
 - Always consult `docs/INDEX.md` to locate the authoritative SPEC or PLAN for the area you’re modifying; keep PR bodies aligned with those docs.
+
+Linear Naming Convention
+- Use zero-padded numeric prefixes for phases and roadmap tasks to guarantee lexical sorting.
+- Phase format: `NN.Phase — <title>` (examples: `00.Phase — Baseline Approvals and Repo Hygiene`, `01.Phase — Core Security Foundations`).
+- Roadmap task format: `NN. <title>` (examples: `01. Auth Store ...`, `12. Site Gateway Topology`).
+- Never use non-padded variants like `Phase 1` or `1. <title>`.


### PR DESCRIPTION
## Summary
- add repo-level guidance in `AGENTS.md` for Linear naming (`NN.Phase` and `NN. task`)
- add an always-apply Cursor rule at `.cursor/rules/linear-naming.mdc`
- add reusable skill `.claude/skills/sync-github-linear/SKILL.md` for GitHub↔Linear sync workflows

## Test plan
- [x] verify rule files exist and are readable
- [x] confirm naming guidance appears in `AGENTS.md`

Made with [Cursor](https://cursor.com)