### PR TITLE
docs(linear): centralize planning docs and timing model

### DIFF
--- a/.claude/skills/sync-github-linear/SKILL.md
+++ b/.claude/skills/sync-github-linear/SKILL.md
@@ -11,9 +11,9 @@ allowed-tools: Read, Glob, CallMcpTool
 Use this workflow to keep GitHub issues and Linear project items synchronized.
 
 ## Scope
-- GitHub roadmap/issues -> Linear issues (create/update/state sync)
+- `docs/ROADMAP.md` -> Linear phase/task hierarchy (primary source of order)
 - `docs/**/*.md` -> Linear docs index (refresh when file list changes)
-- Roadmap phases/tasks from `docs/ROADMAP.md` -> Linear phase/task hierarchy
+- Optional GitHub issue state mirroring when explicitly requested
 
 ## Canonical Mapping
 - **GitHub issue identity marker** in Linear issue description:
@@ -22,6 +22,12 @@ Use this workflow to keep GitHub issues and Linear project items synchronized.
   - file path list + GitHub blob links
 
 Always preserve these markers so updates are idempotent.
+
+## Ordering and Naming (Mandatory)
+- Phase title format: `NN.Phase — <title>`
+- Task title format: `NN. <title>`
+- Phase and milestone must share the same `NN.Phase` key.
+- Task numbering must follow `docs/ROADMAP.md` order exactly.
 
 ## Status Mapping
 - GitHub `OPEN` -> Linear state `Backlog` (or `In Progress` if already active)
@@ -39,14 +45,16 @@ Always preserve these markers so updates are idempotent.
    - If missing, create with `save_project`.
 
 3. **Ensure phase parents exist**
-   - For each GitHub phase issue (e.g., "Phase 0 ..."), find existing Linear issue in project by marker.
+   - Parse phases from `docs/ROADMAP.md` (not from GitHub issue ordering).
    - If missing, `create_issue`.
    - If present, `update_issue` title/description/state.
+   - Ensure a matching milestone exists for each phase (`NN.Phase`).
 
 4. **Ensure roadmap tasks exist and are linked**
    - Parse numbered tasks in `docs/ROADMAP.md`.
    - Create/update each as a child issue (`parentId` = phase issue id).
    - Keep task descriptions linked to relevant spec/plan paths.
+   - Ensure task titles stay `NN. <title>` with two-digit numbering.
 
 5. **Refresh docs index document**
    - Build markdown list of all docs paths with blob links.
@@ -57,7 +65,15 @@ Always preserve these markers so updates are idempotent.
      - OPEN -> `update_issue state=Backlog` (unless actively in progress)
      - CLOSED -> `update_issue state=Done`
 
-7. **Report**
+7. **Apply scheduling metadata**
+   - Set milestone target dates sequentially by phase number.
+   - Add issue metadata fields in descriptions:
+     - `SOURCE_DOC: docs/ROADMAP.md`
+     - `PHASE_KEY`, `TASK_KEY`
+     - `WINDOW_START`, `WINDOW_END`
+     - `ETA_CLASS`
+
+8. **Report**
    - Return counts:
      - created/updated/closed Linear issues
      - created/updated documents
@@ -68,3 +84,4 @@ Always preserve these markers so updates are idempotent.
 - Never change unrelated Linear projects.
 - Keep sync markers in descriptions.
 - Prefer updates over duplicates (idempotent behavior).
+- Do not reorder by creation time; always enforce roadmap numbering.

--- a/.claude/skills/sync-github-linear/SKILL.md
+++ b/.claude/skills/sync-github-linear/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: sync-github-linear
+description: Sync GitHub issues and docs markdown to Linear project state using MCP. Use when user asks to keep GitHub and Linear in sync, mirror open/closed status, or refresh roadmap/docs tasks.
+argument-hint: "--owner <owner> --repo <repo> [--project \"SWAP Roadmap\"]"
+disable-model-invocation: false
+allowed-tools: Read, Glob, CallMcpTool
+---
+
+# Sync GitHub and Linear (MCP)
+
+Use this workflow to keep GitHub issues and Linear project items synchronized.
+
+## Scope
+- GitHub roadmap/issues -> Linear issues (create/update/state sync)
+- `docs/**/*.md` -> Linear docs index (refresh when file list changes)
+- Roadmap phases/tasks from `docs/ROADMAP.md` -> Linear phase/task hierarchy
+
+## Canonical Mapping
+- **GitHub issue identity marker** in Linear issue description:
+  - `SYNC_SOURCE: github:<owner>/<repo>#<number>`
+- **Docs file identity marker** in Linear docs index:
+  - file path list + GitHub blob links
+
+Always preserve these markers so updates are idempotent.
+
+## Status Mapping
+- GitHub `OPEN` -> Linear state `Backlog` (or `In Progress` if already active)
+- GitHub `CLOSED` -> Linear state `Done`
+
+## Workflow
+
+1. **Load source state**
+   - `user-github/list_issues` for `OPEN` and `CLOSED` with pagination as needed.
+   - `Glob` for `docs/**/*.md`.
+   - `Read` `docs/ROADMAP.md`.
+
+2. **Ensure target Linear project exists**
+   - `plugin-linear-linear/list_projects` (query by name).
+   - If missing, create with `save_project`.
+
+3. **Ensure phase parents exist**
+   - For each GitHub phase issue (e.g., "Phase 0 ..."), find existing Linear issue in project by marker.
+   - If missing, `create_issue`.
+   - If present, `update_issue` title/description/state.
+
+4. **Ensure roadmap tasks exist and are linked**
+   - Parse numbered tasks in `docs/ROADMAP.md`.
+   - Create/update each as a child issue (`parentId` = phase issue id).
+   - Keep task descriptions linked to relevant spec/plan paths.
+
+5. **Refresh docs index document**
+   - Build markdown list of all docs paths with blob links.
+   - Create or update a Linear document titled `Docs Mirror Index (docs/)`.
+
+6. **State reconciliation**
+   - For each mapped GitHub issue:
+     - OPEN -> `update_issue state=Backlog` (unless actively in progress)
+     - CLOSED -> `update_issue state=Done`
+
+7. **Report**
+   - Return counts:
+     - created/updated/closed Linear issues
+     - created/updated documents
+     - unmatched/missing mapping entries
+
+## Safety Rules
+- Never delete Linear issues/documents automatically.
+- Never change unrelated Linear projects.
+- Keep sync markers in descriptions.
+- Prefer updates over duplicates (idempotent behavior).

--- a/.cursor/rules/linear-naming.mdc
+++ b/.cursor/rules/linear-naming.mdc
@@ -13,3 +13,10 @@ When creating or renaming Linear milestones/issues/tasks, use zero-padded number
   - Example: `07. Rate Limits and Backpressure Defaults`
 
 Do not use non-padded forms such as `Phase 1`, `Phase 01`, or `1. <title>`.
+
+Additional constraints:
+
+- Use `docs/ROADMAP.md` as the only source of phase/task order.
+- Phase issue and milestone titles must match on the same `NN.Phase` key.
+- Task titles must use roadmap numbering (`01.` through `12.`) in doc order.
+- Set milestone target dates sequentially by phase number to keep UI sorting stable.

--- a/.cursor/rules/linear-naming.mdc
+++ b/.cursor/rules/linear-naming.mdc
@@ -1,0 +1,15 @@
+---
+description: Enforce zero-padded Linear phase and task naming for sort stability
+alwaysApply: true
+---
+
+# Linear Naming Rule
+
+When creating or renaming Linear milestones/issues/tasks, use zero-padded numbering.
+
+- Phase naming: `NN.Phase — <title>`
+  - Example: `01.Phase — Core Security Foundations`
+- Subtask naming: `NN. <title>`
+  - Example: `07. Rate Limits and Backpressure Defaults`
+
+Do not use non-padded forms such as `Phase 1`, `Phase 01`, or `1. <title>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,9 @@ Agent Notes
 - Do not introduce new dependencies casually; justify security impact.
 - Avoid adding license headers or changing licensing unless explicitly requested.
 - Always consult `docs/INDEX.md` to locate the authoritative SPEC or PLAN for the area you’re modifying; keep PR bodies aligned with those docs.
+
+Linear Naming Convention
+- Use zero-padded numeric prefixes for phases and roadmap tasks to guarantee lexical sorting.
+- Phase format: `NN.Phase — <title>` (examples: `00.Phase — Baseline Approvals and Repo Hygiene`, `01.Phase — Core Security Foundations`).
+- Roadmap task format: `NN. <title>` (examples: `01. Auth Store ...`, `12. Site Gateway Topology`).
+- Never use non-padded variants like `Phase 1` or `1. <title>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,6 @@ Linear Naming Convention
 - Phase format: `NN.Phase — <title>` (examples: `00.Phase — Baseline Approvals and Repo Hygiene`, `01.Phase — Core Security Foundations`).
 - Roadmap task format: `NN. <title>` (examples: `01. Auth Store ...`, `12. Site Gateway Topology`).
 - Never use non-padded variants like `Phase 1` or `1. <title>`.
+- Use `docs/ROADMAP.md` as the source of phase/task ordering; do not infer order from issue creation timestamps.
+- Keep phase issues and milestones aligned on the same `NN.Phase` key and use sequential target dates to stabilize sorting.
+- Follow `docs/ops/llm_delivery_timing_ordering_spec.md` for phase windows, ETA classes, and LLM-vs-human timing assumptions.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,8 +6,11 @@ Welcome. Use the Spec Index and Roadmap to navigate:
 - Roadmap: [docs/ROADMAP.md](./ROADMAP.md)
 
 Key Starting Points
+
 - Security policies: routing obfuscation, sessions/CSRF, rate limits
 - Auth/RBAC: internal encrypted auth store, roles matrix
 - Logging: ingestion/normalization, live tail, UI, graphs
 - Plugins: packaging/signing, registry, module UIs
 - Ops: supply chain, upgrades, observability, retention
+- LLM delivery planning: [docs/ops/llm_delivery_timing_ordering_spec.md](./ops/llm_delivery_timing_ordering_spec.md)
+- Linear planning docs: [docs/linear/README.md](./linear/README.md)

--- a/docs/linear/README.md
+++ b/docs/linear/README.md
@@ -1,0 +1,23 @@
+# Linear Planning Docs
+
+Use this section as the single documentation area for Linear planning and sync conventions.
+
+## Documents
+
+- Naming rules: `docs/linear/naming_conventions.md`
+- Task classification and timing policy: `docs/linear/timing_classification.md`
+- Linear field mapping (how markdown fields map to Linear fields): `docs/linear/field_mapping.md`
+- Task issue template (includes required timing table): `docs/linear/task_template.md`
+
+## Canonical Model Data
+
+- Machine-readable effort model: `docs/ops/llm_delivery_timing_ordering_model.json`
+
+## Usage Rule
+
+When creating or updating Linear issues:
+
+1. Follow naming from `naming_conventions.md`.
+2. Compute estimates with `timing_classification.md` + the JSON model.
+3. Populate issue metadata and Linear fields from `field_mapping.md`.
+4. Include the timing table from `task_template.md` at the end of each task issue description.

--- a/docs/linear/field_mapping.md
+++ b/docs/linear/field_mapping.md
@@ -1,0 +1,37 @@
+# Linear Field Mapping
+
+This document maps markdown task metadata to Linear task fields.
+
+## Metadata in Issue Description
+
+Keep these metadata lines in each task description:
+
+- `SOURCE_DOC: docs/ROADMAP.md`
+- `PHASE_KEY: NN`
+- `TASK_KEY: NN`
+- `DIFFICULTY_TIER: XS|S|M|L|XL`
+- `DELIVERY_MODE: HUMAN_ONLY|LLM_ONLY|LLM_PLUS_PERSON`
+- `QA_LEVEL: none|light|standard|deep`
+- `GUI_TESTING: enabled|disabled`
+- `COORDINATION_MODE: single_agent|multi_agent|multi_agent_with_human_gate`
+- `ESTIMATED_MINUTES: <number>`
+- `WINDOW_START: YYYY-MM-DD`
+- `WINDOW_END: YYYY-MM-DD`
+- `ETA_CLASS: <class>`
+
+## Linear Fields
+
+- `title`: from naming conventions in `docs/linear/naming_conventions.md`
+- `project`: `SWAP Roadmap` (or project selected for the sync run)
+- `parent`: phase issue (`NN.Phase`)
+- `milestone`: matching `NN.Phase` milestone
+- `startDate`: from timing calculation
+- `dueDate`: from timing calculation
+- `labels`: include phase label and domain labels when defined
+
+## Sync Requirement
+
+When an estimate changes, update both:
+
+- issue metadata lines (`ESTIMATED_MINUTES`, `WINDOW_START`, `WINDOW_END`)
+- Linear task date fields (`startDate`, `dueDate`, duration equivalent)

--- a/docs/linear/naming_conventions.md
+++ b/docs/linear/naming_conventions.md
@@ -1,0 +1,23 @@
+# Linear Naming Conventions
+
+Use these conventions for deterministic sorting in Linear.
+
+## Phase Naming
+
+- Format: `NN.Phase — <title>`
+- Example: `01.Phase — Core Security Foundations`
+- `NN` is always two digits.
+- Allowed phase range for current roadmap: `00` to `05`.
+
+## Task Naming
+
+- Format: `NN. <title>`
+- Example: `07. Rate Limits and Backpressure Defaults`
+- `NN` is always two digits.
+- Task order must follow `docs/ROADMAP.md` exactly.
+
+## Lock Rules
+
+- Phase issue and milestone must share the same `NN.Phase` key.
+- Do not use variants such as `Phase 1`, `Phase 01`, or `1. <title>`.
+- Do not derive sort order from issue creation timestamps.

--- a/docs/linear/task_template.md
+++ b/docs/linear/task_template.md
@@ -1,0 +1,52 @@
+# Linear Task Template
+
+Use this template when creating roadmap tasks in Linear.
+
+## Template
+
+```md
+## Context
+
+<task goal and scope>
+
+## References
+
+- SOURCE_DOC: docs/ROADMAP.md
+- Related specs/plans: <doc paths>
+
+## Metadata
+
+SOURCE_DOC: docs/ROADMAP.md
+PHASE_KEY: <NN>
+TASK_KEY: <NN>
+DIFFICULTY_TIER: <XS|S|M|L|XL>
+DELIVERY_MODE: <HUMAN_ONLY|LLM_ONLY|LLM_PLUS_PERSON>
+QA_LEVEL: <none|light|standard|deep>
+GUI_TESTING: <enabled|disabled>
+COORDINATION_MODE: <single_agent|multi_agent|multi_agent_with_human_gate>
+ESTIMATED_MINUTES: <number>
+WINDOW_START: <YYYY-MM-DD>
+WINDOW_END: <YYYY-MM-DD>
+ETA_CLASS: <LLM_FAST|LLM_PLUS_TEST|LLM_PLUS_HUMAN_REVIEW|LLM_PLUS_HUMAN_QA>
+
+## Deliverables
+
+- <deliverable 1>
+- <deliverable 2>
+
+## Task Timing Table
+
+| Classification | Time Required (min) | Total Time (min) |
+| --- | ---: | ---: |
+| Base (difficulty) | <base_human_minutes> | <base_human_minutes> |
+| Delivery mode applied | <base_human_minutes * delivery_multiplier> | <running_total> |
+| QA overhead | <addon_minutes> | <running_total> |
+| GUI overhead | <addon_minutes> | <running_total> |
+| Coordination overhead | <addon_minutes> | <running_total> |
+| Final estimate | - | <ESTIMATED_MINUTES> |
+```
+
+## Required Placement
+
+- Keep `Task Timing Table` at the end of each task description.
+- Keep metadata block present for deterministic sync updates.

--- a/docs/linear/timing_classification.md
+++ b/docs/linear/timing_classification.md
@@ -1,0 +1,50 @@
+# Linear Task Classification and Timing
+
+This document defines how to classify tasks and calculate planned duration for Linear.
+
+## Inputs
+
+- Difficulty tier: `XS`, `S`, `M`, `L`, `XL`
+- Delivery mode: `HUMAN_ONLY`, `LLM_ONLY`, `LLM_PLUS_PERSON`
+- QA level: `none`, `light`, `standard`, `deep`
+- GUI testing: `enabled`, `disabled`
+- Coordination mode: `single_agent`, `multi_agent`, `multi_agent_with_human_gate`
+
+## Canonical Calculator
+
+Use the canonical model file:
+
+- `docs/ops/llm_delivery_timing_ordering_model.json`
+
+Apply formula:
+
+- `estimate_minutes = round(base_human_minutes * delivery_multiplier * (1 + qa_addon + gui_addon + coordination_addon))`
+
+## Date and Duration Transfer Policy
+
+After calculating `estimate_minutes`, write all of the following to the task:
+
+- `ESTIMATED_MINUTES` metadata field in the issue body
+- Linear `startDate`
+- Linear `dueDate`
+- Linear `duration` (minutes or the equivalent duration field used by your sync flow)
+
+Use these conversion rules for planning:
+
+- If `estimate_minutes` <= 480: start and end on same day.
+- If `estimate_minutes` > 480: split across consecutive working days.
+- Round end times to the nearest 15 minutes.
+- If task depends on another task, set `startDate` to the next working slot after the dependency end.
+
+## Required Task Timing Table
+
+Every task issue description must end with this table shape:
+
+| Classification | Time Required (min) | Total Time (min) |
+| --- | ---: | ---: |
+| Base (difficulty) | `<base_human_minutes>` | `<base_human_minutes>` |
+| Delivery mode applied | `<base_human_minutes * delivery_multiplier>` | `<running_total>` |
+| QA overhead | `<addon_minutes>` | `<running_total>` |
+| GUI overhead | `<addon_minutes>` | `<running_total>` |
+| Coordination overhead | `<addon_minutes>` | `<running_total>` |
+| Final estimate | `-` | `<ESTIMATED_MINUTES>` |

--- a/docs/ops/llm_delivery_timing_ordering_model.json
+++ b/docs/ops/llm_delivery_timing_ordering_model.json
@@ -1,0 +1,107 @@
+{
+  "model_name": "swap_llm_effort_v1",
+  "units": "minutes",
+  "formula": {
+    "code": "estimate = round(base_human_minutes * delivery_multiplier * (1 + qa_addon + gui_addon + coordination_addon))",
+    "explanation": "Start from difficulty baseline, apply delivery mode ratio, then add testing/coordination overhead."
+  },
+  "difficulty_tiers": {
+    "XS": {
+      "base_human_minutes": 30,
+      "explanation": "Small text/config tweak, single-file, low risk."
+    },
+    "S": {
+      "base_human_minutes": 60,
+      "explanation": "Simple implementation task with limited validation."
+    },
+    "M": {
+      "base_human_minutes": 120,
+      "explanation": "Moderate feature/fix across multiple files with tests."
+    },
+    "L": {
+      "base_human_minutes": 240,
+      "explanation": "Complex multi-component change with integration concerns."
+    },
+    "XL": {
+      "base_human_minutes": 480,
+      "explanation": "Large architectural or high-risk change requiring staged validation."
+    }
+  },
+  "delivery_modes": {
+    "HUMAN_ONLY": {
+      "delivery_multiplier": 1.0,
+      "explanation": "Human implementation without LLM acceleration."
+    },
+    "LLM_ONLY": {
+      "delivery_multiplier": 0.1,
+      "explanation": "LLM-led execution (1/10 of human baseline). Example: S=60 -> 6 min."
+    },
+    "LLM_PLUS_PERSON": {
+      "delivery_multiplier": 0.2,
+      "explanation": "LLM with human oversight/review (1/5 of human baseline). Example: S=60 -> 12 min."
+    }
+  },
+  "overheads": {
+    "qa_addon": {
+      "none": 0.0,
+      "light": 0.1,
+      "standard": 0.2,
+      "deep": 0.35,
+      "explanation": "Non-GUI validation overhead fraction."
+    },
+    "gui_addon": {
+      "enabled": 0.05,
+      "disabled": 0.0,
+      "explanation": "GUI test overhead set to 1/20 (+5%) of baseline-adjusted effort."
+    },
+    "coordination_addon": {
+      "single_agent": 0.0,
+      "multi_agent": 0.1,
+      "multi_agent_with_human_gate": 0.2,
+      "explanation": "Prompt alignment, merge/reconcile, and handoff overhead."
+    }
+  },
+  "examples": [
+    {
+      "input": {
+        "difficulty": "S",
+        "delivery_mode": "LLM_ONLY",
+        "qa": "none",
+        "gui": "disabled",
+        "coordination": "single_agent"
+      },
+      "output_minutes": 6,
+      "explanation": "Matches target example for LLM-only."
+    },
+    {
+      "input": {
+        "difficulty": "S",
+        "delivery_mode": "LLM_PLUS_PERSON",
+        "qa": "none",
+        "gui": "disabled",
+        "coordination": "single_agent"
+      },
+      "output_minutes": 12,
+      "explanation": "Matches target example for LLM+person."
+    },
+    {
+      "input": {
+        "difficulty": "M",
+        "delivery_mode": "LLM_PLUS_PERSON",
+        "qa": "standard",
+        "gui": "enabled",
+        "coordination": "multi_agent"
+      },
+      "output_minutes": 30,
+      "explanation": "Includes QA, GUI overhead, and multi-agent coordination."
+    }
+  ],
+  "metadata_fields_for_issues": [
+    "DIFFICULTY_TIER",
+    "DELIVERY_MODE",
+    "QA_LEVEL",
+    "GUI_TESTING",
+    "COORDINATION_MODE",
+    "ESTIMATED_MINUTES"
+  ]
+}

--- a/docs/ops/llm_delivery_timing_ordering_spec.md
+++ b/docs/ops/llm_delivery_timing_ordering_spec.md
@@ -1,0 +1,101 @@
+# LLM Delivery Timing and Ordering Spec
+
+This document defines how roadmap phases/tasks are named, ordered, and scheduled for LLM-led execution.
+
+## Source of Truth
+
+- Roadmap sequencing MUST come from `docs/ROADMAP.md`.
+- Do not derive phase/task order from GitHub issue creation order.
+
+## Deterministic Ordering
+
+Use these exact title formats:
+
+- Phase: `NN.Phase — <title>`
+  - Example: `01.Phase — Core Security Foundations`
+- Task: `NN. <title>`
+  - Example: `07. Rate Limits and Backpressure Defaults`
+
+Rules:
+
+- `NN` is always two digits.
+- Phase numbers are `00` to `05`.
+- Task numbers follow `docs/ROADMAP.md` numbering (`01` to `12`).
+- No alternative formats (`Phase 1`, `1.`, `Phase 01`) are allowed.
+
+## Phase-Milestone Lock
+
+Each phase issue MUST match exactly one milestone with the same title prefix:
+
+- `00.Phase ...` issue -> `00.Phase ...` milestone
+- `01.Phase ...` issue -> `01.Phase ...` milestone
+- etc.
+
+If mismatch occurs, rename and relink to restore one-to-one alignment.
+
+## Date and Time Span Policy
+
+Because this project is LLM-led, default durations are shorter than human-only plans.
+
+- Milestone target dates should be sequential by phase order.
+- Phase windows should be documented in each phase issue description as:
+  - `WINDOW_START: YYYY-MM-DD`
+  - `WINDOW_END: YYYY-MM-DD`
+
+Recommended baseline:
+
+- Phase 00: +1 day from planning date
+- Phase 01: +2 days
+- Phase 02: +3 days
+- Phase 03: +4 days
+- Phase 04: +5 days
+- Phase 05: +6 days
+
+## Task Duration Expectations
+
+Use these planning classes in task descriptions:
+
+- `ETA_CLASS: LLM_FAST` -> 2-6 hours (implementation + self-check)
+- `ETA_CLASS: LLM_PLUS_TEST` -> 4-10 hours (implementation + automated tests)
+- `ETA_CLASS: LLM_PLUS_HUMAN_REVIEW` -> 1-2 days
+- `ETA_CLASS: LLM_PLUS_HUMAN_QA` -> 2-3 days
+
+Human inspection/testing extends timelines and should be explicit.
+
+## JSON Effort Model (Minutes)
+
+Canonical machine-readable source:
+
+- `docs/ops/llm_delivery_timing_ordering_model.json`
+
+Canonical Linear planning docs:
+
+- `docs/linear/README.md`
+- `docs/linear/timing_classification.md`
+- `docs/linear/task_template.md`
+
+## Parallel Agent Model
+
+Multiple agents may be assigned per task when scope allows:
+
+- Claude: implementation and refactor pass
+- Google plugin workflow: research/spec reconciliation
+- Gemini anti-gravity: validation and test pressure
+
+Parallelization guidance:
+
+- 2 agents: typically 25-40% faster than single-agent flow
+- 3 agents: typically 35-55% faster, with additional merge/reconciliation overhead
+
+## Required Metadata for Sync
+
+For each phase/task issue, keep these fields in description:
+
+- `SOURCE_DOC: docs/ROADMAP.md`
+- `PHASE_KEY: NN`
+- `TASK_KEY: NN` (tasks only)
+- `WINDOW_START: YYYY-MM-DD`
+- `WINDOW_END: YYYY-MM-DD`
+- `ETA_CLASS: <class>`
+
+These fields make syncing deterministic and auditable.


### PR DESCRIPTION
## Summary
- add a dedicated `docs/linear/` section for naming conventions, timing/classification policy, field mapping, and task templates
- add canonical machine-readable model at `docs/ops/llm_delivery_timing_ordering_model.json` and reference it from spec docs
- align repo guidance/rules/skill docs so Linear task ordering and scheduling metadata remain deterministic

## Test plan
- [x] markdown lint checks pass for changed docs (no linter errors reported)
- [x] verify links in `docs/INDEX.md` include new linear docs entrypoint
- [x] verify JSON model is valid and matches timing formula/ratios in spec docs

Made with [Cursor](https://cursor.com)