### PR TITLE
docs(gui): add multi-LLM orchestration workflow, templates, and skill

### DIFF
--- a/.claude/skills/gui-dss-orchestration/SKILL.md
+++ b/.claude/skills/gui-dss-orchestration/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gui-dss-orchestration
+description: Create and execute GUI test Task Cards and DSS reports for Antigravity, Claude Codebook, and Claude Google plugin. Use when the user asks for GUI test coordination, cross-LLM handoffs, expected-vs-actual reporting, or standardized test run updates.
+argument-hint: "--task-id <GUI-id> --owner-tool <tool> [--status <status>]"
+disable-model-invocation: false
+allowed-tools: Bash, Read
+---
+
+# GUI DSS Orchestration
+
+Use this workflow to run GUI tasks with a consistent handoff and reporting method.
+
+## Source of Truth
+
+- `docs/ops/gui_llm_test_orchestration_spec.md`
+- `docs/ops/templates/gui_task_card_template.yaml`
+- `docs/ops/templates/gui_dss_report_template.yaml`
+
+When generating output, always preserve these fields:
+
+- `TASK_ID`
+- `TASK_REQUIRED`
+- `EXPECTED_OUTCOME`
+- `ACTUAL_OUTCOME`
+
+## Trigger Conditions
+
+Apply this skill when the request mentions:
+
+- GUI testing across multiple LLM tools
+- Antigravity, Claude Codebook, Claude Google plugin handoffs
+- expected vs actual result reporting
+- DSS, task cards, or standard operating workflow
+
+## Workflow
+
+1. Identify target scope:
+   - screen/module
+   - environment
+   - build id or commit
+2. Create or update a Task Card from `gui_task_card_template.yaml`.
+3. Execute or document run steps in deterministic order.
+4. Create a DSS report from `gui_dss_report_template.yaml`.
+5. Set `NEXT_ACTION` with explicit owner/action/due.
+6. If all acceptance checks pass, set status to `CLOSED`; otherwise keep `FAILED` or `BLOCKED`.
+
+## Output Contract
+
+### Task Card rules
+
+- Keep `TASK_ID` stable across revisions.
+- Keep acceptance checks binary and testable.
+- Do not leave `TASK_REQUIRED` or `EXPECTED_OUTCOME` blank.
+
+### DSS rules
+
+- Always include `TASK_REQUIRED`, `EXPECTED_OUTCOME`, `ACTUAL_OUTCOME`.
+- If mismatch exists, add at least one `DEVIATIONS` entry.
+- For `FAILED` or `BLOCKED`, `NEXT_ACTION` must be concrete.
+- `CLOSED` requires acceptance checks resolved.
+
+## Compact Chat Update Format
+
+Use this plain-text format for progress updates:
+
+```text
+[DSS] TASK_ID=<id> TOOL=<tool> STATUS=<status>
+Required: <task required>
+Method: <how executed>
+Expected: <expected outcome>
+Actual: <actual outcome>
+Deviation: <none|short mismatch statement>
+Evidence: <artifact refs>
+Next: <owner + action + due>
+```

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,4 +13,6 @@ Key Starting Points
 - Plugins: packaging/signing, registry, module UIs
 - Ops: supply chain, upgrades, observability, retention
 - LLM delivery planning: [docs/ops/llm_delivery_timing_ordering_spec.md](./ops/llm_delivery_timing_ordering_spec.md)
+- Multi-LLM GUI test coordination: [docs/ops/gui_llm_test_orchestration_spec.md](./ops/gui_llm_test_orchestration_spec.md)
+- Multi-LLM GUI test usage guide: [docs/ops/gui_llm_test_orchestration_usage.md](./ops/gui_llm_test_orchestration_usage.md)
 - Linear planning docs: [docs/linear/README.md](./linear/README.md)

--- a/docs/ops/gui_llm_test_orchestration_spec.md
+++ b/docs/ops/gui_llm_test_orchestration_spec.md
@@ -1,0 +1,186 @@
+# SPEC: Multi-LLM GUI Test Orchestration and DSS Reporting
+
+## Goal
+
+Define one standard method for coordinating GUI testing across:
+
+- Antigravity
+- Claude Codebook
+- Claude Google plugin
+
+This method standardizes:
+
+- what task is required,
+- how each tool should execute the task,
+- expected and actual outcomes, and
+- how each tool reports back via DSS.
+
+## Terms
+
+- DSS: `Delivery Status Snapshot` (the required report payload after each step).
+- Task Card: the canonical handoff object that tells the next tool what to do.
+- Run: a single execution attempt by one tool against one Task Card.
+
+## Templates (Canonical)
+
+- Task Card template: `docs/ops/templates/gui_task_card_template.yaml`
+- DSS report template: `docs/ops/templates/gui_dss_report_template.yaml`
+
+## Operating Model
+
+Use a baton-pass workflow with one active owner at a time:
+
+1. Plan and split GUI work into numbered Task Cards.
+2. Assign one tool as active owner.
+3. Active owner executes and publishes a DSS.
+4. Next owner picks up the same Task Card revision (or a new revision if changed).
+5. Final owner publishes closure DSS with pass/fail and evidence index.
+
+Status values:
+
+- `QUEUED`
+- `IN_PROGRESS`
+- `BLOCKED`
+- `FAILED`
+- `PASSED`
+- `CLOSED`
+
+## Standard Task Card (Required Fields)
+
+Every GUI task must be created in this structure:
+
+```yaml
+TASK_ID: GUI-<feature>-<nn>
+TASK_TITLE: <short action-oriented title>
+SCOPE:
+  area: <screen/module>
+  environment: <local/staging/prod-like>
+  build: <commit sha or build id>
+OWNER_TOOL: <antigravity|claude-codebook|claude-google-plugin>
+NEXT_TOOL: <antigravity|claude-codebook|claude-google-plugin|none>
+PRECONDITIONS:
+  - <state that must already exist>
+PROCEDURE:
+  - <step 1>
+  - <step 2>
+EXPECTED_OUTCOME:
+  - <observable expected behavior>
+EVIDENCE_REQUIREMENTS:
+  - screenshot
+  - console-log-snippet
+  - network-observation
+ACCEPTANCE_CHECKS:
+  - <binary pass/fail check>
+  - <binary pass/fail check>
+```
+
+Rules:
+
+- `TASK_ID` must be stable across all handoffs.
+- `PROCEDURE` must be deterministic and reproducible.
+- `EXPECTED_OUTCOME` must be observable and testable.
+- `ACCEPTANCE_CHECKS` must be binary (pass/fail), not subjective.
+
+## DSS Report Contract (Required After Every Run)
+
+Each run must publish one DSS payload:
+
+```yaml
+DSS_VERSION: 1
+TASK_ID: GUI-<feature>-<nn>
+RUN_ID: <uuid-or-timestamp>
+TOOL: <antigravity|claude-codebook|claude-google-plugin>
+STATUS: <IN_PROGRESS|BLOCKED|FAILED|PASSED|CLOSED>
+START_TIME: <ISO-8601>
+END_TIME: <ISO-8601>
+TASK_REQUIRED: <what was requested>
+METHOD_USED:
+  - <how task was executed>
+EXPECTED_OUTCOME:
+  - <copied from Task Card>
+ACTUAL_OUTCOME:
+  - <what really happened>
+DEVIATIONS:
+  - <expected vs actual mismatch, if any>
+EVIDENCE_INDEX:
+  screenshots:
+    - <path-or-url>
+  logs:
+    - <path-or-url>
+  traces:
+    - <path-or-url>
+NEXT_ACTION:
+  owner: <tool-or-human>
+  action: <specific next step>
+  due: <ISO-8601 or none>
+```
+
+Rules:
+
+- `TASK_REQUIRED`, `EXPECTED_OUTCOME`, and `ACTUAL_OUTCOME` are mandatory.
+- If there is any mismatch, `DEVIATIONS` must be non-empty.
+- `FAILED` or `BLOCKED` must always include a concrete `NEXT_ACTION`.
+- `CLOSED` requires all `ACCEPTANCE_CHECKS` resolved.
+
+## Tool Role Guidance
+
+Use these default responsibilities unless explicitly overridden:
+
+- Antigravity
+  - Primary UI traversal and behavior validation under realistic user paths.
+  - Capture interaction evidence (screenshots, sequence of actions).
+- Claude Codebook
+  - Convert findings into precise technical deltas and reproducible checks.
+  - Validate whether implementation matches expected behavior contract.
+- Claude Google plugin
+  - Cross-check known framework/browser behavior and edge-case expectations.
+  - Validate external references and compatibility assumptions.
+
+## Standard Workflow
+
+1. Author Task Card
+   - Define required task, method, expected outcome, and binary checks.
+2. Claim Ownership
+   - Set `OWNER_TOOL` and mark `IN_PROGRESS`.
+3. Execute
+   - Run only documented procedure steps; note any additional diagnostic steps.
+4. Publish DSS
+   - Submit complete DSS with evidence links/paths.
+5. Handoff
+   - Assign `NEXT_TOOL` with explicit next action.
+6. Resolve
+   - Final owner marks `CLOSED` or escalates with `FAILED` and action plan.
+
+## Reporting Format for Chat/Issue Updates
+
+When posting updates, use this compact report:
+
+```text
+[DSS] TASK_ID=<id> TOOL=<tool> STATUS=<status>
+Required: <task required>
+Method: <how executed>
+Expected: <expected outcome>
+Actual: <actual outcome>
+Deviation: <none|short mismatch statement>
+Evidence: <artifact refs>
+Next: <owner + action + due>
+```
+
+## Example
+
+```text
+[DSS] TASK_ID=GUI-login-flow-01 TOOL=antigravity STATUS=FAILED
+Required: Validate session timeout warning modal appears after idle threshold.
+Method: Logged in as test user, idled for configured timeout, resumed interaction.
+Expected: Warning modal appears before forced sign-out.
+Actual: Session is terminated directly without warning modal.
+Deviation: Missing pre-expiry warning behavior.
+Evidence: screenshots/sess-timeout-01.png, logs/browser-console-22.txt
+Next: claude-codebook to inspect modal trigger path and propose fix by 2026-02-25T12:00:00Z.
+```
+
+## Governance
+
+- Store Task Cards and DSS reports with project artifacts (PR description, issue thread, or tracked run logs).
+- Do not close GUI tasks without a closure DSS.
+- Any change to expected behavior requires a new Task Card revision with a changelog note.

--- a/docs/ops/gui_llm_test_orchestration_usage.md
+++ b/docs/ops/gui_llm_test_orchestration_usage.md
@@ -1,0 +1,117 @@
+# GUIDE: Using Multi-LLM GUI Test Orchestration
+
+## Purpose
+
+This guide explains how to use the GUI orchestration workflow in daily delivery work.
+
+It is the practical companion to:
+
+- `docs/ops/gui_llm_test_orchestration_spec.md`
+- `.claude/skills/gui-dss-orchestration/SKILL.md`
+
+## What to Use
+
+- Task Card template: `docs/ops/templates/gui_task_card_template.yaml`
+- DSS template: `docs/ops/templates/gui_dss_report_template.yaml`
+- Skill: `.claude/skills/gui-dss-orchestration/SKILL.md`
+
+## Standard Day-to-Day Flow
+
+1. Create a Task Card
+   - Copy `gui_task_card_template.yaml`.
+   - Fill scope, required task, deterministic procedure, expected outcome, and acceptance checks.
+2. Assign the first tool owner
+   - Set `OWNER_TOOL`.
+   - Set `STATUS: IN_PROGRESS`.
+3. Execute the run
+   - Owner follows only the documented procedure.
+   - Capture evidence required by the card.
+4. Publish DSS
+   - Copy `gui_dss_report_template.yaml`.
+   - Fill `TASK_REQUIRED`, `EXPECTED_OUTCOME`, `ACTUAL_OUTCOME`, `DEVIATIONS`, and evidence paths.
+5. Handoff or close
+   - Set `NEXT_ACTION` with owner/action/due.
+   - Set `NEXT_TOOL` in Task Card.
+   - If all acceptance checks pass, close with `STATUS: CLOSED`.
+
+## Ownership Model
+
+Use one active owner at a time:
+
+- Antigravity: realistic UI path execution and interaction evidence capture.
+- Claude Codebook: technical reconciliation and implementation-alignment checks.
+- Claude Google plugin: framework/browser behavior cross-check and edge-case validation.
+
+## Status Rules (Enforced)
+
+- `FAILED` or `BLOCKED` must include a concrete `NEXT_ACTION`.
+- Any expected-vs-actual mismatch must populate `DEVIATIONS`.
+- `CLOSED` is allowed only when acceptance checks are resolved.
+- Keep `TASK_ID` stable across all handoffs and revisions.
+
+## Folder Convention
+
+For each GUI task, store artifacts under one folder:
+
+```text
+artifacts/gui/<task-id>/
+  task-card.yaml
+  dss/
+    2026-02-24T101500Z-antigravity.yaml
+    2026-02-24T111000Z-claude-codebook.yaml
+  screenshots/
+  logs/
+  traces/
+```
+
+This keeps evidence and history auditable.
+
+## Prompting Pattern for LLM-Driven Runs
+
+Use this prompt structure when invoking an LLM tool:
+
+```text
+Use gui-dss-orchestration.
+Task card path: <path>
+DSS output path: <path>
+Act as OWNER_TOOL=<tool>.
+Follow PROCEDURE exactly.
+Return a completed DSS including TASK_REQUIRED, EXPECTED_OUTCOME, ACTUAL_OUTCOME, DEVIATIONS, and NEXT_ACTION.
+```
+
+## Copy/Paste Operational Checklist
+
+```text
+GUI Orchestration Checklist
+- [ ] Task Card created from template
+- [ ] TASK_REQUIRED filled
+- [ ] EXPECTED_OUTCOME filled and testable
+- [ ] Acceptance checks binary
+- [ ] Owner assigned and status IN_PROGRESS
+- [ ] Evidence captured to task artifact folder
+- [ ] DSS published with EXPECTED vs ACTUAL
+- [ ] DEVIATIONS filled if mismatch exists
+- [ ] NEXT_ACTION set for handoff or fix
+- [ ] Task closed only with resolved checks
+```
+
+## Example Run Update
+
+```text
+[DSS] TASK_ID=GUI-login-flow-01 TOOL=antigravity STATUS=FAILED
+Required: Validate timeout warning modal before forced sign-out.
+Method: Logged in as test user, idled to threshold, resumed interaction.
+Expected: Warning modal appears before sign-out.
+Actual: Immediate sign-out; no warning modal.
+Deviation: Missing warning modal behavior.
+Evidence: artifacts/gui/GUI-login-flow-01/screenshots/timeout.png, artifacts/gui/GUI-login-flow-01/logs/console.txt
+Next: claude-codebook to inspect modal trigger path and propose code fix by 2026-02-25T12:00:00Z.
+```
+
+## Common Mistakes to Avoid
+
+- Writing subjective acceptance checks (must be pass/fail).
+- Closing tasks without a final DSS.
+- Changing `TASK_ID` during handoffs.
+- Omitting evidence references in DSS.
+- Omitting `NEXT_ACTION` on blocked/failed runs.

--- a/docs/ops/templates/gui_dss_report_template.yaml
+++ b/docs/ops/templates/gui_dss_report_template.yaml
@@ -1,0 +1,46 @@
+DSS_VERSION: 1
+TASK_ID: GUI-<feature>-<nn>
+TASK_REVISION: 1
+RUN_ID: <uuid-or-timestamp>
+TOOL: <antigravity|claude-codebook|claude-google-plugin>
+STATUS: <IN_PROGRESS|BLOCKED|FAILED|PASSED|CLOSED>
+
+START_TIME: <ISO-8601>
+END_TIME: <ISO-8601>
+
+TASK_REQUIRED: <copied from task card>
+
+METHOD_USED:
+  - <how the tool executed the task>
+
+EXPECTED_OUTCOME:
+  - <copied from task card>
+
+ACTUAL_OUTCOME:
+  - <observed behavior and result>
+
+DEVIATIONS:
+  - <expected-vs-actual mismatch, or "none">
+
+EVIDENCE_INDEX:
+  screenshots:
+    - <path-or-url>
+  logs:
+    - <path-or-url>
+  traces:
+    - <path-or-url>
+
+ACCEPTANCE_RESULTS:
+  - id: AC-01
+    result: <PASS|FAIL|N/A>
+    note: <short rationale>
+  - id: AC-02
+    result: <PASS|FAIL|N/A>
+    note: <short rationale>
+
+NEXT_ACTION:
+  owner: <tool-or-human>
+  action: <specific next step>
+  due: <ISO-8601-or-none>
+
+REPORTER: <agent-or-human-name>

--- a/docs/ops/templates/gui_task_card_template.yaml
+++ b/docs/ops/templates/gui_task_card_template.yaml
@@ -1,0 +1,39 @@
+TASK_ID: GUI-<feature>-<nn>
+TASK_TITLE: <short action-oriented title>
+TASK_REVISION: 1
+SOURCE_SPEC: docs/ops/gui_llm_test_orchestration_spec.md
+
+SCOPE:
+  area: <screen-or-module>
+  environment: <local|staging|prod-like>
+  build: <commit-sha-or-build-id>
+
+OWNER_TOOL: <antigravity|claude-codebook|claude-google-plugin>
+NEXT_TOOL: <antigravity|claude-codebook|claude-google-plugin|none>
+STATUS: QUEUED
+
+PRECONDITIONS:
+  - <state that must already exist>
+
+PROCEDURE:
+  - <deterministic step 1>
+  - <deterministic step 2>
+
+TASK_REQUIRED: <what must be validated or delivered>
+
+EXPECTED_OUTCOME:
+  - <observable expected behavior>
+
+EVIDENCE_REQUIREMENTS:
+  - screenshot
+  - console-log-snippet
+  - network-observation
+
+ACCEPTANCE_CHECKS:
+  - id: AC-01
+    check: <binary pass/fail statement>
+  - id: AC-02
+    check: <binary pass/fail statement>
+
+NOTES:
+  - <optional notes>


### PR DESCRIPTION
## Summary
- add a formal multi-LLM GUI orchestration spec for Antigravity, Claude Codebook, and Claude Google plugin
- add canonical Task Card and DSS YAML templates for deterministic handoff, expected-vs-actual tracking, and evidence indexing
- add a project skill (`gui-dss-orchestration`) plus a practical usage guide to make the workflow fully LLM-driven in daily operations

## Test plan
- [x] verify docs and templates are committed and linked from `docs/INDEX.md`
- [x] run lints/diagnostics for changed docs files in editor tooling
- [x] confirm branch is clean and includes only intended GUI orchestration changes

Made with [Cursor](https://cursor.com)