### PR TITLE
feat(k3s): K3s infrastructure migration with mkdocs site and internal docs

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,0 +1,15 @@
+# .docs — Internal Documentation
+
+This directory contains internal documentation for LLM-assisted development workflows. These files are version-controlled but hidden by dot-prefix convention.
+
+## Structure
+
+- **`architecture-decisions/`** — Architecture Decision Records (ADRs) for key technical choices
+- **`context/`** — Project context documents for onboarding LLMs and contributors
+- **`workflows/`** — Development workflow documentation
+
+## Convention
+
+ADRs follow a simple format: **Context**, **Decision**, **Consequences**.
+
+Files in this directory are starting from the K3s infrastructure migration phase forward. Historical decisions before this point are not documented here.

--- a/.docs/architecture-decisions/001-k3s-over-docker.md
+++ b/.docs/architecture-decisions/001-k3s-over-docker.md
@@ -1,0 +1,32 @@
+# ADR-001: K3s Over Docker Compose
+
+## Context
+
+SWAP was originally designed to run via Docker Compose for local development and single-node deployments. As the platform matured, requirements emerged for:
+
+- Network-level isolation between trust zones (DMZ, internal, monitoring)
+- Declarative workload management with health checks, rolling updates, and resource limits
+- Multi-node deployment without custom orchestration scripts
+- GitOps-driven configuration management
+
+Docker Compose cannot provide network isolation between trust zones without complex manual iptables rules, and lacks native support for multi-node orchestration.
+
+## Decision
+
+Replace Docker Compose with K3s as the primary deployment target. K3s provides:
+
+- Lightweight Kubernetes with a single binary and low resource overhead
+- Native support for NetworkPolicies (via Cilium CNI) for trust zone isolation
+- Helm charts for declarative, repeatable deployments
+- Rancher Fleet integration for GitOps multi-cluster management
+- StatefulSet support for PostgreSQL and other stateful workloads
+
+The single-image Docker deployment remains available for development and testing.
+
+## Consequences
+
+- **Positive**: True network isolation, declarative management, multi-node scaling, GitOps
+- **Positive**: K3s has lower overhead than full Kubernetes distributions
+- **Negative**: Higher operational complexity than Docker Compose
+- **Negative**: Requires Kubernetes knowledge for day-2 operations
+- **Mitigation**: Helm charts and Rancher Fleet reduce operational burden

--- a/.docs/architecture-decisions/002-alpine-over-distroless.md
+++ b/.docs/architecture-decisions/002-alpine-over-distroless.md
@@ -1,0 +1,29 @@
+# ADR-002: Alpine 3.22 Over Distroless Debian
+
+## Context
+
+SWAP container images need a minimal runtime base. Two candidates were evaluated:
+
+1. **Distroless Debian** (`gcr.io/distroless/static-debian12`) — Google's minimal images with no shell or package manager
+2. **Alpine 3.22** (`alpine:3.22`) — Minimal Linux distribution with musl libc
+
+Both provide small image sizes and reduced attack surface. The key differentiator is the C library: Distroless uses glibc, Alpine uses musl.
+
+## Decision
+
+Use Alpine 3.22 as the runtime base image. Rust binaries are compiled with `RUSTFLAGS='-C target-feature=+crt-static'` to produce fully static musl binaries.
+
+Reasons:
+
+- **musl-static binaries** have zero runtime dependencies — the binary is self-contained
+- **Alpine's apk** is available during debugging (not in production images, but useful for ephemeral debug containers)
+- **Smaller base image** — Alpine 3.22 is ~7MB vs Distroless static at ~2MB, but the static binary makes the base layer irrelevant for security
+- **Better Rust ecosystem support** — `x86_64-unknown-linux-musl` is a tier-2 Rust target with good CI support
+- **Consistency** — K3s itself runs on Alpine-based nodes in many deployments
+
+## Consequences
+
+- **Positive**: Fully static binaries with no dynamic linking surprises
+- **Positive**: Consistent musl toolchain across build and runtime
+- **Negative**: Some C dependencies (e.g., OpenSSL) need musl-compatible builds — mitigated by using `rustls` instead of OpenSSL
+- **Negative**: Alpine's musl may have subtle behavioral differences from glibc — not relevant for Rust's standard library

--- a/.docs/architecture-decisions/003-multi-cluster-topology.md
+++ b/.docs/architecture-decisions/003-multi-cluster-topology.md
@@ -1,0 +1,29 @@
+# ADR-003: Multi-Cluster Topology (4-Zone Split)
+
+## Context
+
+A security platform handling sensitive data needs strict isolation between components with different trust levels. A single Kubernetes cluster with namespaces provides logical isolation but not network-level isolation — a compromised pod can potentially reach any other pod in the cluster.
+
+## Decision
+
+Deploy SWAP across four dedicated K3s clusters, each in a separate network zone:
+
+| Cluster | Trust Level | Purpose |
+|---------|-------------|---------|
+| **DMZ** | Lowest | Public-facing ingress, WAF, TLS termination |
+| **Core** | Highest | Controller, auth, database, agent management |
+| **ETL/Data** | Medium | Log ingestion, transformation, storage |
+| **Monitoring** | Medium | Prometheus, Grafana, Alertmanager, Loki |
+
+Each cluster has its own control plane, etcd, and Cilium CNI. Inter-cluster communication uses routable IPs with mTLS — no shared overlay network.
+
+An optional Rancher management cluster provides fleet-level visibility.
+
+## Consequences
+
+- **Positive**: A compromised DMZ pod cannot reach Core cluster pods — true network isolation
+- **Positive**: Each cluster can be sized, updated, and scaled independently
+- **Positive**: Blast radius of any failure is contained to one zone
+- **Negative**: Higher infrastructure cost (4+ control planes)
+- **Negative**: More complex networking setup (routable IPs, firewall rules, mTLS between clusters)
+- **Mitigation**: Rancher Fleet provides single-pane management across all clusters

--- a/.docs/architecture-decisions/004-headlamp-rancher-management.md
+++ b/.docs/architecture-decisions/004-headlamp-rancher-management.md
@@ -1,0 +1,25 @@
+# ADR-004: Per-Cluster Headlamp + Rancher Fleet Management
+
+## Context
+
+Multi-cluster Kubernetes deployments need management tooling for:
+
+1. **Per-cluster visibility** — Viewing workloads, logs, and events in each cluster
+2. **Fleet-level management** — Deploying configurations across all clusters from a single source of truth
+
+## Decision
+
+Use a two-layer management approach:
+
+- **Headlamp** — Deployed per-cluster as a lightweight Kubernetes dashboard. Provides read-only visibility into workloads, pod logs, and events without requiring kubectl access.
+- **Rancher Fleet** — Deployed on a dedicated management cluster (or co-located on Core for dev/staging). Provides GitOps-driven configuration management across all clusters.
+
+Rancher Fleet watches the `deploy/k3s/rancher/fleet.yaml` configuration and applies Helm charts to target clusters based on labels.
+
+## Consequences
+
+- **Positive**: Developers get per-cluster dashboards without kubectl complexity
+- **Positive**: GitOps ensures all cluster configurations are version-controlled and auditable
+- **Positive**: Rancher Fleet supports staged rollouts and drift detection
+- **Negative**: Rancher adds operational overhead (its own cluster, upgrades, RBAC)
+- **Mitigation**: Rancher is optional — clusters can be managed directly with kubectl and Helm

--- a/.docs/context/how-specs-work.md
+++ b/.docs/context/how-specs-work.md
@@ -1,0 +1,39 @@
+# How Specs Work
+
+## SPEC Template Convention
+
+All specifications in `docs/` follow a consistent structure:
+
+### Required Sections
+
+1. **Goals** — What the spec achieves (bulleted list)
+2. **Non-Goals** — What is explicitly out of scope
+3. **Architecture Overview** — High-level design with Mermaid diagrams
+4. **Detailed Design** — Implementation specifics, configuration examples, data flows
+5. **Open Questions** — Unresolved decisions (removed when resolved)
+
+### Optional Sections
+
+- **Per-Component Breakdown** — Tables or subsections for each component
+- **Operational Runbook** — Day-2 operations, troubleshooting, scaling procedures
+- **Security Considerations** — Threat model, trust boundaries, attack surface
+
+## File Naming
+
+Specs use snake_case with a `_spec.md` suffix:
+- `k3s_infrastructure_spec.md`
+- `single_image_spec.md`
+- `secrets_management_spec.md`
+
+## Spec Location
+
+Specs are organized by domain under `docs/`:
+- `docs/deploy/` — Deployment and infrastructure
+- `docs/security/` — Security, PKI, secrets
+- `docs/network/` — Networking, ingress, gateway
+- `docs/ops/` — Operations, monitoring, upgrades
+- `docs/agent/` — Agent management, isolation
+
+## Mermaid Diagrams
+
+All architecture diagrams use Mermaid syntax (validated by CI via `mermaid-validate.yml`). Prefer `flowchart TB` or `flowchart LR` for architecture diagrams and `sequenceDiagram` for interaction flows.

--- a/.docs/context/project-overview.md
+++ b/.docs/context/project-overview.md
@@ -1,0 +1,36 @@
+# SWAP Project Overview
+
+## What is SWAP?
+
+SWAP (Secure Web Application Platform) is a security-first platform for deploying, managing, and monitoring distributed security agents. Built entirely in Rust, it provides a hardened control plane for security operations.
+
+## Current State (K3s Migration Phase)
+
+The project is migrating from Docker Compose to K3s multi-cluster deployment. Key artifacts:
+
+### Specifications
+- `docs/deploy/k3s_infrastructure_spec.md` — Full K3s deployment specification
+- `docs/deploy/single_image_spec.md` — Single-image Docker deployment (dev/test)
+- `docs/network/site_gateway_spec.md` — DMZ ingress topology
+- `docs/security/secrets_management_spec.md` — Secrets and PKI management
+- `docs/ops/observability_metrics_spec.md` — Monitoring stack specification
+
+### Helm Charts
+- `deploy/k3s/charts/swap-core/` — Core cluster (controller, auth, PostgreSQL)
+- `deploy/k3s/charts/swap-dmz/` — DMZ cluster (Traefik, WAF)
+- `deploy/k3s/charts/swap-etl/` — ETL cluster (log ingestion)
+- `deploy/k3s/charts/swap-monitoring/` — Monitoring cluster (Prometheus, Grafana)
+- `deploy/k3s/rancher/fleet.yaml` — Rancher Fleet configuration
+
+### Codebase
+- `crates/` — Rust workspace with all SWAP services
+- `proto/` — Protocol Buffer definitions
+- `migrations/` — Database migrations
+
+## Key Technical Decisions
+
+See `.docs/architecture-decisions/` for ADRs covering:
+- K3s over Docker Compose (ADR-001)
+- Alpine 3.22 over Distroless (ADR-002)
+- Multi-cluster topology (ADR-003)
+- Headlamp + Rancher management (ADR-004)

--- a/.docs/workflows/pr-workflow.md
+++ b/.docs/workflows/pr-workflow.md
@@ -1,0 +1,58 @@
+# PR Workflow
+
+## Branch → PR → CI → Merge → Delete
+
+### 1. Create Feature Branch
+
+```bash
+git checkout -b feat/<descriptive-name>
+# or: docs/<name>, fix/<name>, ci/<name>, chore/<name>
+```
+
+### 2. Commit and Push
+
+```bash
+git add <specific-files>
+git commit -m "type(scope): description"
+git push -u origin feat/<descriptive-name>
+```
+
+Commit message prefixes: `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`
+
+### 3. Create PR
+
+```bash
+gh pr create --title "type(scope): description" --body "..."
+```
+
+PR title must pass the `semantic-pr-title.yml` CI check.
+
+### 4. CI Checks
+
+Required checks before merge:
+- **ci.yml** — Rust build, clippy lints, tests
+- **docs-quality.yml** — Markdown linting, link checking (lychee)
+- **codespell** — Spell checking
+- **mermaid-validate.yml** — Mermaid diagram syntax validation
+- **semantic-pr-title.yml** — PR title format validation
+
+### 5. Merge
+
+Branch protection requires:
+- All CI checks passing
+- Linear history (squash merge)
+- Admin approval
+
+```bash
+gh pr merge <number> --squash --delete-branch
+```
+
+### 6. Cleanup
+
+The `--delete-branch` flag deletes the remote branch after merge. Local cleanup:
+
+```bash
+git checkout main
+git pull
+git branch -d feat/<descriptive-name>
+```

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,22 +2,34 @@ name: GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material pymdown-extensions
+      - name: Build site
+        run: mkdocs build --strict
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: site_build
+
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .vscode/
 dist/
 coverage/
+site_build/

--- a/deploy/k3s/charts/swap-core/Chart.yaml
+++ b/deploy/k3s/charts/swap-core/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: swap-core
+description: >-
+  SWAP Core cluster Helm chart. Deploys the Controller (gRPC/mTLS on port
+  10443), PostgreSQL (via Bitnami subchart), and Headlamp dashboard.
+version: 0.1.0
+appVersion: "0.1.0"
+type: application
+
+keywords:
+  - swap
+  - controller
+  - core
+  - security
+
+maintainers:
+  - name: SWAP Team
+
+dependencies:
+  - name: postgresql
+    version: "~16.4"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/deploy/k3s/charts/swap-core/templates/deployment.yaml
+++ b/deploy/k3s/charts/swap-core/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swap-core.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "swap-core.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "swap-core.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+      containers:
+        - name: controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: grpc-mtls
+              containerPort: 10443
+              protocol: TCP
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            capabilities:
+              drop:
+                {{- range .Values.securityContext.capabilities.drop }}
+                - {{ . }}
+                {{- end }}
+            seccompProfile:
+              type: {{ .Values.securityContext.seccompProfile.type }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: certs
+              mountPath: {{ .Values.volumes.certs.mountPath }}
+              readOnly: true
+            - name: plugins
+              mountPath: {{ .Values.volumes.plugins.mountPath }}
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            grpc:
+              port: 10443
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            grpc:
+              port: 10443
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: certs
+          secret:
+            secretName: {{ .Values.volumes.certs.secretName }}
+        - name: plugins
+          emptyDir: {}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/deploy/k3s/charts/swap-core/templates/networkpolicy.yaml
+++ b/deploy/k3s/charts/swap-core/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+# -- Default-deny all ingress and egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "swap-core.fullname" . }}-default-deny
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# -- Allow controller ingress from DMZ on gRPC/mTLS port
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "swap-core.fullname" . }}-allow-controller
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              swap.zone: dmz
+      ports:
+        - protocol: TCP
+          port: 10443
+  egress:
+    # Allow DNS resolution
+    - to: []
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow egress to PostgreSQL
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}

--- a/deploy/k3s/charts/swap-core/templates/pdb.yaml
+++ b/deploy/k3s/charts/swap-core/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "swap-core.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "swap-core.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: controller
+{{- end }}

--- a/deploy/k3s/charts/swap-core/templates/service.yaml
+++ b/deploy/k3s/charts/swap-core/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "swap-core.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: grpc-mtls
+      protocol: {{ .Values.service.protocol }}
+      name: {{ .Values.service.name }}
+  selector:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: controller

--- a/deploy/k3s/charts/swap-core/templates/serviceaccount.yaml
+++ b/deploy/k3s/charts/swap-core/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "swap-core.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/k3s/charts/swap-core/values.yaml
+++ b/deploy/k3s/charts/swap-core/values.yaml
@@ -1,0 +1,81 @@
+# -- SWAP Core default values
+
+replicaCount: 2
+
+image:
+  repository: swap-controller
+  tag: latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: swap-controller
+  automountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 10443
+  protocol: TCP
+  name: grpc-mtls
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+
+volumes:
+  certs:
+    mountPath: /etc/swap/certs
+    secretName: swap-mtls-certs
+  plugins:
+    mountPath: /opt/swap/plugins
+    emptyDir: true
+
+# -- Bitnami PostgreSQL subchart values
+postgresql:
+  enabled: true
+  auth:
+    database: swap
+    username: swap
+    existingSecret: swap-postgresql-secret
+  primary:
+    persistence:
+      size: 10Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+    containerSecurityContext:
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault

--- a/deploy/k3s/charts/swap-dmz/Chart.yaml
+++ b/deploy/k3s/charts/swap-dmz/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: swap-dmz
+description: >-
+  SWAP DMZ cluster Helm chart. Deploys Traefik ingress with Coraza WAF
+  sidecar, reverse proxy to Core cluster, and Headlamp dashboard.
+version: 0.1.0
+appVersion: "0.1.0"
+type: application
+
+keywords:
+  - swap
+  - dmz
+  - waf
+  - ingress
+  - traefik
+  - coraza
+
+maintainers:
+  - name: SWAP Team

--- a/deploy/k3s/charts/swap-dmz/templates/deployment.yaml
+++ b/deploy/k3s/charts/swap-dmz/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swap-dmz.fullname" . }}-proxy
+  labels:
+    app.kubernetes.io/name: {{ include "swap-dmz.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: proxy
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "swap-dmz.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "swap-dmz.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: proxy
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+      containers:
+        # -- Traefik reverse proxy
+        - name: traefik
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: backend-mtls
+              containerPort: 10443
+              protocol: TCP
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            capabilities:
+              drop:
+                {{- range .Values.securityContext.capabilities.drop }}
+                - {{ . }}
+                {{- end }}
+            seccompProfile:
+              type: {{ .Values.securityContext.seccompProfile.type }}
+          resources:
+            {{- toYaml .Values.proxy.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+        # -- Coraza WAF sidecar
+        - name: coraza-waf
+          image: "{{ .Values.waf.image.repository }}:{{ .Values.waf.image.tag }}"
+          imagePullPolicy: {{ .Values.waf.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            capabilities:
+              drop:
+                {{- range .Values.securityContext.capabilities.drop }}
+                - {{ . }}
+                {{- end }}
+            seccompProfile:
+              type: {{ .Values.securityContext.seccompProfile.type }}
+          resources:
+            {{- toYaml .Values.waf.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/deploy/k3s/charts/swap-dmz/templates/networkpolicy.yaml
+++ b/deploy/k3s/charts/swap-dmz/templates/networkpolicy.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.networkPolicy.enabled }}
+# -- Default-deny all ingress and egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "swap-dmz.fullname" . }}-default-deny
+  labels:
+    app.kubernetes.io/name: {{ include "swap-dmz.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# -- Allow external HTTPS ingress and egress to Core cluster
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "swap-dmz.fullname" . }}-allow-proxy
+  labels:
+    app.kubernetes.io/name: {{ include "swap-dmz.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow HTTPS from any (public internet via LoadBalancer)
+    - ports:
+        - protocol: TCP
+          port: 443
+  egress:
+    # Allow DNS resolution
+    - to: []
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow egress to Core cluster on gRPC/mTLS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              swap.zone: core
+      ports:
+        - protocol: TCP
+          port: 10443
+{{- end }}

--- a/deploy/k3s/charts/swap-dmz/values.yaml
+++ b/deploy/k3s/charts/swap-dmz/values.yaml
@@ -1,0 +1,58 @@
+# -- SWAP DMZ default values
+
+replicaCount: 2
+
+waf:
+  image:
+    repository: owasp/coraza-proxy-wasm
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+proxy:
+  image:
+    repository: traefik
+    tag: "3.3"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+serviceAccount:
+  create: true
+  name: swap-dmz-proxy
+  automountServiceAccountToken: false
+
+service:
+  type: LoadBalancer
+  httpsPort: 443
+  backendPort: 10443
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+networkPolicy:
+  enabled: true
+
+backend:
+  coreServiceHost: swap-core-controller.swap-core.svc.cluster.local
+  coreServicePort: 10443

--- a/deploy/k3s/charts/swap-etl/Chart.yaml
+++ b/deploy/k3s/charts/swap-etl/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: swap-etl
+description: >-
+  SWAP ETL cluster Helm chart. Deploys log ingestion workers for
+  security event processing with optional MinIO object storage.
+version: 0.1.0
+appVersion: "0.1.0"
+type: application
+
+keywords:
+  - swap
+  - etl
+  - ingestion
+  - logs
+
+maintainers:
+  - name: SWAP Team
+
+dependencies:
+  - name: minio
+    version: "~5.4"
+    repository: https://charts.min.io/
+    condition: minio.enabled

--- a/deploy/k3s/charts/swap-etl/templates/deployment.yaml
+++ b/deploy/k3s/charts/swap-etl/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swap-etl.fullname" . }}-worker
+  labels:
+    app.kubernetes.io/name: {{ include "swap-etl.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ingestion-worker
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "swap-etl.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: ingestion-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "swap-etl.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: ingestion-worker
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+      containers:
+        - name: ingestion-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            capabilities:
+              drop:
+                {{- range .Values.securityContext.capabilities.drop }}
+                - {{ . }}
+                {{- end }}
+            seccompProfile:
+              type: {{ .Values.securityContext.seccompProfile.type }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi

--- a/deploy/k3s/charts/swap-etl/values.yaml
+++ b/deploy/k3s/charts/swap-etl/values.yaml
@@ -1,0 +1,50 @@
+# -- SWAP ETL default values
+
+replicaCount: 2
+
+image:
+  repository: swap-ingestion-worker
+  tag: latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: swap-etl-worker
+  automountServiceAccountToken: false
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 1Gi
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+networkPolicy:
+  enabled: true
+
+# -- MinIO subchart values
+minio:
+  enabled: false
+  replicas: 4
+  persistence:
+    size: 50Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi

--- a/deploy/k3s/charts/swap-monitoring/Chart.yaml
+++ b/deploy/k3s/charts/swap-monitoring/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: swap-monitoring
+description: >-
+  SWAP Monitoring cluster Helm chart. Deploys Prometheus, Grafana,
+  Alertmanager, and Loki via the kube-prometheus-stack subchart.
+version: 0.1.0
+appVersion: "0.1.0"
+type: application
+
+keywords:
+  - swap
+  - monitoring
+  - prometheus
+  - grafana
+  - alertmanager
+  - loki
+
+maintainers:
+  - name: SWAP Team
+
+dependencies:
+  - name: kube-prometheus-stack
+    version: "~69.8"
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: kube-prometheus-stack.enabled
+  - name: loki
+    version: "~6.29"
+    repository: https://grafana.github.io/helm-charts
+    condition: loki.enabled

--- a/deploy/k3s/charts/swap-monitoring/templates/deployment.yaml
+++ b/deploy/k3s/charts/swap-monitoring/templates/deployment.yaml
@@ -1,0 +1,52 @@
+# -- Monitoring stack is deployed via subchart dependencies
+# (kube-prometheus-stack and loki). This manifest provides a
+# monitoring-agent sidecar ConfigMap and any custom resources
+# not covered by the subcharts.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "swap-monitoring.fullname" . }}-dashboards
+  labels:
+    app.kubernetes.io/name: {{ include "swap-monitoring.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: grafana
+    grafana_dashboard: "true"
+data:
+  swap-overview.json: |-
+    {
+      "annotations": { "list": [] },
+      "title": "SWAP Overview",
+      "uid": "swap-overview",
+      "version": 1,
+      "panels": []
+    }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "swap-monitoring.fullname" . }}-alerts
+  labels:
+    app.kubernetes.io/name: {{ include "swap-monitoring.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: alerting
+spec:
+  groups:
+    - name: swap.rules
+      rules:
+        - alert: SwapControllerDown
+          expr: up{job="swap-controller"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "SWAP Controller is down"
+            description: "The SWAP controller has been unreachable for 5 minutes."
+        - alert: SwapHighErrorRate
+          expr: rate(swap_request_errors_total[5m]) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High error rate on SWAP controller"
+            description: "Error rate exceeds 5% over the last 10 minutes."

--- a/deploy/k3s/charts/swap-monitoring/values.yaml
+++ b/deploy/k3s/charts/swap-monitoring/values.yaml
@@ -1,0 +1,92 @@
+# -- SWAP Monitoring default values
+
+serviceAccount:
+  create: true
+  name: swap-monitoring
+  automountServiceAccountToken: false
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+networkPolicy:
+  enabled: true
+
+# -- kube-prometheus-stack subchart values
+kube-prometheus-stack:
+  enabled: true
+  prometheus:
+    prometheusSpec:
+      retention: 30d
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 4Gi
+      securityContext:
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+
+  grafana:
+    enabled: true
+    adminPassword: ""  # Set via secret
+    persistence:
+      enabled: true
+      size: 5Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  alertmanager:
+    enabled: true
+    alertmanagerSpec:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+
+# -- Loki subchart values
+loki:
+  enabled: true
+  loki:
+    auth_enabled: false
+  singleBinary:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi

--- a/deploy/k3s/rancher/fleet.yaml
+++ b/deploy/k3s/rancher/fleet.yaml
@@ -1,0 +1,48 @@
+# -- Rancher Fleet GitOps configuration for SWAP multi-cluster deployment
+# Ref: https://fleet.rancher.io/ref-fleet-yaml
+
+defaultNamespace: swap-system
+
+helm:
+  releaseName: swap
+
+targetCustomizations:
+  # -- Core cluster: Controller + PostgreSQL + Headlamp
+  - name: swap-core
+    clusterSelector:
+      matchLabels:
+        swap.zone: core
+    helm:
+      chart: deploy/k3s/charts/swap-core
+      valuesFiles:
+        - deploy/k3s/charts/swap-core/values.yaml
+
+  # -- DMZ cluster: Traefik ingress + Coraza WAF + Headlamp
+  - name: swap-dmz
+    clusterSelector:
+      matchLabels:
+        swap.zone: dmz
+    helm:
+      chart: deploy/k3s/charts/swap-dmz
+      valuesFiles:
+        - deploy/k3s/charts/swap-dmz/values.yaml
+
+  # -- ETL cluster: Ingestion workers + optional MinIO
+  - name: swap-etl
+    clusterSelector:
+      matchLabels:
+        swap.zone: etl
+    helm:
+      chart: deploy/k3s/charts/swap-etl
+      valuesFiles:
+        - deploy/k3s/charts/swap-etl/values.yaml
+
+  # -- Monitoring cluster: Prometheus + Grafana + Alertmanager + Loki
+  - name: swap-monitoring
+    clusterSelector:
+      matchLabels:
+        swap.zone: monitoring
+    helm:
+      chart: deploy/k3s/charts/swap-monitoring
+      valuesFiles:
+        - deploy/k3s/charts/swap-monitoring/values.yaml

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,3 +16,5 @@ Key Starting Points
 - Multi-LLM GUI test coordination: [docs/ops/gui_llm_test_orchestration_spec.md](./ops/gui_llm_test_orchestration_spec.md)
 - Multi-LLM GUI test usage guide: [docs/ops/gui_llm_test_orchestration_usage.md](./ops/gui_llm_test_orchestration_usage.md)
 - Linear planning docs: [docs/linear/README.md](./linear/README.md)
+- K3s infrastructure deployment: [docs/deploy/k3s_infrastructure_spec.md](./deploy/k3s_infrastructure_spec.md)
+- Helm chart scaffolds: [deploy/k3s/](../deploy/k3s/) (swap-core, swap-dmz, swap-etl, swap-monitoring)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,11 +79,26 @@ This document sequences implementation work into reviewable milestones with clea
     - Deliverables: Blue/green controller; agent canary; plugin pins/rollback.
     - Acceptance: Staged rollouts with rollback on failure.
 
-## Phase 5 — Extensions (Optional)
+## Phase 5 — K3s Infrastructure Migration
 
-12. Site Gateway Topology
-    - SPEC: docs/network/site_gateway_spec.md (PR #30)
-    - Acceptance: Relay behavior defined and validated in a test site.
+12. Alpine 3.22 Image Build
+    - SPEC: docs/deploy/k3s_infrastructure_spec.md
+    - Deliverables: Multi-stage Dockerfile (`rust:1-bookworm` builder, `alpine:3.22` runtime); musl static binary; OCI image signing.
+    - Acceptance: Image builds in CI; cosign-verified; passes Trivy scan.
+
+13. Core Cluster Helm Chart + K3s Deployment
+    - SPEC: docs/deploy/k3s_infrastructure_spec.md
+    - Deliverables: `swap-core` Helm chart (Controller, PostgreSQL, Auth Store, Plugin Registry); Headlamp; embedded etcd HA; `--secrets-encryption`.
+    - Acceptance: Controller deploys on K3s; gRPC/mTLS functional; agents connect.
+
+14. Multi-Cluster Topology (DMZ, ETL, Monitoring)
+    - SPEC: docs/deploy/k3s_infrastructure_spec.md; docs/network/site_gateway_spec.md (DMZ cluster supersedes site gateway for K3s deployments)
+    - Deliverables: `swap-dmz` (Traefik + Coraza WAF), `swap-etl` (ingestion workers), `swap-monitoring` (Prometheus federation, Grafana, Alertmanager, Loki) Helm charts.
+    - Acceptance: Inter-cluster mTLS validated; NetworkPolicies enforce default-deny; Prometheus federation operational.
+
+15. Rancher Fleet Management
+    - Deliverables: Rancher Fleet GitOps config; cluster registration; coordinated rollouts.
+    - Acceptance: Fleet syncs all charts from Git; staged rollouts across clusters.
 
 ## Cross-Cutting Security
 - Route obfuscation (static slugs) — PR #20
@@ -97,6 +112,8 @@ This document sequences implementation work into reviewable milestones with clea
 - Phase 1 must be completed before Phase 2.
 - Rate limits (Phase 3) depend on Phase 1 SSE endpoint.
 - Node-less build can proceed after SSR routes are in place.
+- Phase 5 (K3s migration) can proceed in parallel with Phases 2-4; requires Phase 1 controller binary to be functional.
+- Alpine image build (Phase 5, item 12) is a prerequisite for all K3s cluster deployments.
 
 ## Status Tracking
 - Use PR numbers in this roadmap for review ordering.

--- a/docs/agent/isolation_apply_spec.md
+++ b/docs/agent/isolation_apply_spec.md
@@ -38,5 +38,15 @@ sequenceDiagram
 ## Acceptance Criteria
 - Documented helper capabilities per plugin category; apply/rollback sequence; probes and backoff.
 
+## DaemonSet Agent Mode (K3s Deployments)
+
+In K3s deployments, agents can run as DaemonSet pods on K3s nodes:
+- **SecurityContext**: `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `seccompProfile.type: RuntimeDefault`.
+- **Privileged operations**: Use init containers or sidecar containers with narrowly scoped capabilities (e.g., `CAP_NET_ADMIN` for nftables) instead of elevating the main agent process. Init containers run once at startup; sidecars handle ongoing privileged operations via a Unix socket API.
+- **Host access**: Where agents need host-level access (e.g., nftables, AppArmor), use `hostPID: false`, `hostNetwork: false`, and mount only specific host paths (`/etc/nftables.d`, `/etc/apparmor.d`) as read-only where possible.
+- **Standalone mode**: For external hosts not running K3s, agents continue to run as standalone binaries with systemd confinement as described above.
+
+See [K3s Infrastructure Spec](../deploy/k3s_infrastructure_spec.md) for DaemonSet deployment details.
+
 ## Open Questions
 - Common helper framework vs per-plugin helpers.

--- a/docs/deploy/k3s_infrastructure_spec.md
+++ b/docs/deploy/k3s_infrastructure_spec.md
@@ -1,0 +1,322 @@
+# SPEC: K3s Infrastructure Deployment
+
+## Goals
+- Define a production-grade K3s deployment topology for SWAP across four isolated cluster zones (Core, DMZ, ETL/Data, Monitoring/Obs) with an optional Rancher management cluster.
+- Standardise Alpine 3.22-based container images built as musl-static Rust binaries.
+- Establish inter-cluster networking via routable IPs and mTLS -- no shared overlay network.
+- Provide a clear Helm chart structure and operational runbook for day-2 management.
+
+## Non-Goals
+- Running all SWAP components in a single monolithic cluster.
+- Using a managed Kubernetes service (EKS, GKE, AKS); this spec targets bare-metal and VM deployments.
+- Replacing the SWAP PKI with K3s internal PKI -- the two remain separate (see `docs/security/pki_enrollment_spec.md`).
+- Prescribing specific hardware; node sizing is left to capacity-planning documentation.
+
+## Architecture Overview
+
+Four K3s clusters are deployed in separate network zones. Each cluster is self-contained with its own control plane, CNI, and etcd. An optional Rancher instance provides fleet-level visibility and GitOps-driven configuration across all clusters.
+
+```mermaid
+flowchart TB
+  subgraph mgmt["Rancher Management"]
+    R[Rancher Server]
+  end
+
+  subgraph core["Core / Internal K3s"]
+    CTRL[Controller]
+    AUTH[Auth Store]
+    PG[PostgreSQL]
+    AMGMT[Agent Management]
+    PREG[Plugin Registry]
+  end
+
+  subgraph dmz["DMZ K3s"]
+    TF[Traefik Reverse Proxy]
+    WAF[Coraza WAF]
+    TLS_T[TLS Termination]
+  end
+
+  subgraph etl["ETL / Data K3s"]
+    LIW[Log Ingestion Workers]
+    TJ[Transformation Jobs]
+    MINIO[MinIO - optional]
+  end
+
+  subgraph obs["Monitoring / Obs K3s"]
+    PROM[Prometheus - federation]
+    GRAF[Grafana]
+    AM[Alertmanager]
+    LOKI[Loki]
+  end
+
+  R -->|manages| core
+  R -->|manages| dmz
+  R -->|manages| etl
+  R -->|manages| obs
+
+  dmz -->|mTLS| core
+  core -->|mTLS| etl
+  core -->|mTLS| obs
+  etl -->|mTLS| obs
+```
+
+### Per-Cluster Composition
+
+| Cluster | Workloads | Notes |
+|---------|-----------|-------|
+| **Core/Internal** | Controller, Auth Store, PostgreSQL (StatefulSet), Agent Management, Plugin Registry | Primary data plane; highest trust zone |
+| **DMZ** | Traefik ingress, Coraza WAF sidecar, TLS termination | Only cluster with public-facing endpoints |
+| **ETL/Data** | Log ingestion workers (Deployments), transformation CronJobs, MinIO (optional) | Scales horizontally for burst ingestion |
+| **Monitoring/Obs** | Prometheus (federated), Grafana, Alertmanager, Loki | Scrapes all clusters; receives push from ETL |
+| **Rancher (optional)** | Rancher Server, Fleet controller | Dedicated cluster in production; co-located on Core for dev/staging |
+
+## Detailed Design
+
+### Container Image Build Pipeline
+
+All SWAP images follow a two-stage build producing minimal Alpine 3.22 runtime images.
+
+```mermaid
+flowchart LR
+  subgraph build["Stage 1: Builder"]
+    SRC[Source Code] --> BUILDER["rust:1-bookworm"]
+    BUILDER -->|"cargo build --release --target x86_64-unknown-linux-musl"| BIN[Static Binary]
+  end
+
+  subgraph runtime["Stage 2: Runtime"]
+    BIN --> ALPINE["alpine:3.22"]
+    ALPINE --> IMG["Final Image<br/>non-root user<br/>read-only rootfs<br/>no shell, no package manager"]
+  end
+
+  IMG --> REG[OCI Registry]
+```
+
+Key properties of the runtime image:
+
+- Base: `alpine:3.22` (musl libc compatible).
+- Binary: statically linked via `x86_64-unknown-linux-musl` target; no runtime library dependencies.
+- User: non-root (`uid=10001`, `gid=10001`).
+- Filesystem: read-only root; `tmpfs` at `/tmp` and `/run`.
+- Removed: shell, package manager, all dev tooling stripped in final stage.
+- Signing: images signed with cosign; provenance attestation attached (see `docs/ops/supply_chain_release_spec.md`).
+
+### K3s Cluster Configuration
+
+Each K3s cluster is deployed with:
+
+- **Embedded etcd** for HA (3-node control plane minimum in production).
+- **`--secrets-encryption`** flag enabled on all server nodes to encrypt Secrets at rest in etcd.
+- **Flannel VXLAN** as the default CNI (per-cluster); no shared CNI across clusters.
+- **Traefik disabled** on non-DMZ clusters (`--disable=traefik`); DMZ cluster uses Traefik with Coraza WAF middleware.
+- **ServiceLB disabled** on Core/ETL/Obs clusters where external access is not required (`--disable=servicelb`).
+
+#### nftables Namespace Isolation
+
+K3s (via kube-proxy in iptables/nftables mode) manages its own firewall rules. To avoid conflicts with SWAP-managed nftables rules:
+
+- SWAP rules live in a dedicated nftables table: `table inet swap_policy`.
+- K3s/kube-proxy rules remain in the default `filter`/`nat` tables.
+- A startup script validates that no chain name collisions exist between the `swap_policy` table and kube-proxy-managed chains.
+- The SWAP nftables plugin (see `docs/plugins/nftables_ui_spec.md`) is aware of this separation and never writes to kube-proxy-owned chains.
+
+### Inter-Cluster Networking
+
+```mermaid
+flowchart LR
+  subgraph dmz_net["DMZ Cluster"]
+    DP[DMZ Pod] -->|NodePort/LB routable IP| CP
+  end
+
+  subgraph core_net["Core Cluster"]
+    CP[Core Pod]
+    CP -->|NodePort routable IP| EP
+  end
+
+  subgraph etl_net["ETL Cluster"]
+    EP[ETL Pod]
+    EP -->|NodePort routable IP| OP
+  end
+
+  subgraph obs_net["Obs Cluster"]
+    OP[Obs Pod]
+  end
+
+  DP -.->|mTLS| CP
+  CP -.->|mTLS| EP
+  CP -.->|mTLS| OP
+  EP -.->|mTLS| OP
+```
+
+Principles:
+
+- **No shared overlay network** between clusters. All inter-cluster communication uses routable IPs (host network or LoadBalancer VIPs) plus mTLS.
+- **mTLS certificates** are issued by the SWAP PKI (not the K3s internal CA). See `docs/security/pki_enrollment_spec.md`.
+- **NodePort or LoadBalancer** services expose inter-cluster endpoints. In production, a dedicated LoadBalancer (MetalLB or hardware) provides stable VIPs.
+- **NetworkPolicy** enforces default-deny ingress on every namespace; explicit allow rules are defined per service pair.
+- **DNS**: each cluster runs its own CoreDNS. Cross-cluster service discovery uses ExternalName services or static endpoint configuration managed via Helm values.
+
+### SWAP PKI vs K3s Internal PKI
+
+| Concern | PKI | Notes |
+|---------|-----|-------|
+| Kubelet, API server, etcd peer certs | K3s internal CA | Managed automatically by K3s |
+| Inter-cluster mTLS (service-to-service) | SWAP CA | Issued via SWAP enrollment; rotated independently |
+| Agent-to-Controller mTLS | SWAP CA | See `docs/security/pki_enrollment_spec.md` |
+| Ingress TLS (public-facing) | External CA / ACME | DMZ cluster only |
+
+The two PKI hierarchies never share trust roots. K3s internal certificates are not used outside their respective cluster boundary.
+
+### Management Plane
+
+- **Headlamp**: deployed as an in-cluster Deployment on each K3s cluster for per-cluster dashboarding and ad-hoc inspection. Access gated by RBAC ServiceAccounts scoped to read-only by default.
+- **Rancher**: optional fleet management layer. In production, runs on a dedicated single-node K3s cluster. In dev/staging, co-located on the Core cluster. Rancher provides:
+  - Centralized cluster registration and lifecycle management.
+  - GitOps-driven Helm chart deployment via Fleet.
+  - Unified RBAC view across clusters (Rancher RBAC maps to per-cluster Kubernetes RBAC).
+  - Cluster health monitoring and alerting integration.
+
+### Agents
+
+SWAP agents are deployed in two modes:
+
+| Mode | Where | Mechanism |
+|------|-------|-----------|
+| **DaemonSet pods** | K3s host nodes | Runs on every K3s node; mounts host filesystem read-only for inspection; uses hostNetwork for nftables management |
+| **Standalone binary** | External hosts (non-K3s) | Installed via package or container; connects to Controller over mTLS; managed via Agent Management API |
+
+DaemonSet agents run with `hostPID: true` and `hostNetwork: true` but still enforce `readOnlyRootFilesystem: true`, `runAsNonRoot: true` (where possible), and drop all capabilities except the minimum required set (`NET_ADMIN` for nftables, `SYS_PTRACE` for process inspection).
+
+### Storage Classes
+
+| Environment | Storage Class | Backend | Notes |
+|-------------|--------------|---------|-------|
+| Dev / CI | `local-path` | K3s built-in local-path-provisioner | Single-node; no replication |
+| Production | `longhorn` | Longhorn distributed block storage | 2-replica minimum; snapshot-based backup |
+
+- PostgreSQL and MinIO StatefulSets use PersistentVolumeClaims bound to the appropriate storage class.
+- Longhorn is deployed via its Helm chart on production clusters; configured with daily snapshot schedules and S3-compatible offsite backup targets.
+- Secrets encryption at rest is handled by K3s `--secrets-encryption`; volume-level encryption (LUKS) is recommended for production nodes.
+
+### Helm Chart Structure
+
+```
+charts/
+  swap-core/           # Controller, Auth Store, Agent Mgmt, Plugin Registry
+    templates/
+      deployment.yaml
+      statefulset-pg.yaml
+      service.yaml
+      networkpolicy.yaml
+      secret.yaml        # references external secret; see docs/security/secrets_management_spec.md
+    values.yaml
+  swap-dmz/            # Traefik, Coraza WAF sidecar
+    templates/
+    values.yaml
+  swap-etl/            # Ingestion workers, transformation jobs, MinIO
+    templates/
+    values.yaml
+  swap-obs/            # Prometheus, Grafana, Alertmanager, Loki
+    templates/
+    values.yaml
+  swap-agent/          # DaemonSet agent
+    templates/
+      daemonset.yaml
+      networkpolicy.yaml
+    values.yaml
+  swap-common/         # Shared templates (NetworkPolicy defaults, SecurityContext helpers)
+    templates/
+    values.yaml
+```
+
+Each chart includes:
+
+- `NetworkPolicy` templates with default-deny ingress and explicit allow rules.
+- `SecurityContext` defaults applied via `swap-common` helper templates.
+- Values files with per-environment overrides (`values-dev.yaml`, `values-staging.yaml`, `values-prod.yaml`).
+
+## Security Posture
+
+### Pod Security
+
+All SWAP pods enforce the following `securityContext`:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+```
+
+Exceptions (DaemonSet agents only, documented and audited):
+
+```yaml
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_ADMIN    # nftables rule management
+      - SYS_PTRACE   # process inspection
+```
+
+### Network Policy
+
+- Every namespace has a default-deny ingress `NetworkPolicy`.
+- Explicit allow rules are scoped to specific pod selectors and ports.
+- Egress policies restrict outbound traffic to known destinations (other SWAP services, DNS, NTP).
+
+### Secrets Management
+
+- Kubernetes Secrets are encrypted at rest via K3s `--secrets-encryption`.
+- Application-level secrets (database credentials, PKI keys) follow the external secrets workflow defined in `docs/security/secrets_management_spec.md`.
+- No secrets are baked into container images.
+
+### Runtime
+
+- No SSH into containers or nodes in production.
+- Audit logging enabled on the K3s API server (`--kube-apiserver-arg=audit-log-path=/var/log/k3s-audit.log`).
+- Pod Security Standards enforced at the namespace level (`restricted` profile for all namespaces except `kube-system`).
+
+## Operations
+
+### Deployment
+
+- Initial cluster bootstrap uses `k3sup` or equivalent automation.
+- Helm charts are deployed via Rancher Fleet (GitOps) or `helm install` for standalone environments.
+- Upgrade procedures follow `docs/ops/upgrades_spec.md`; K3s binary upgrades use the system-upgrade-controller.
+
+### Monitoring
+
+- Each cluster exposes metrics to the Monitoring/Obs cluster via Prometheus federation over mTLS.
+- Grafana dashboards are provisioned as ConfigMaps within the `swap-obs` chart.
+- Alertmanager routes follow the escalation paths defined in `docs/ops/observability_metrics_spec.md`.
+
+### Backup and Recovery
+
+- etcd snapshots taken every 6 hours on all clusters; retained for 7 days.
+- Longhorn volume snapshots taken daily; replicated offsite.
+- Disaster recovery runbook covers single-node failure, full cluster rebuild, and cross-cluster failover scenarios.
+
+### Scaling
+
+- ETL/Data cluster supports Horizontal Pod Autoscaler on ingestion workers.
+- Core cluster PostgreSQL scales vertically; read replicas for query-heavy workloads.
+- Additional K3s agent nodes are joined via standard `k3s agent` with the cluster token.
+
+## Acceptance Criteria
+
+- Four K3s clusters deploy successfully with embedded etcd HA (3 control-plane nodes each in production).
+- All SWAP container images build from `rust:1-bookworm` builder to `alpine:3.22` runtime with zero CVEs in the runtime layer.
+- Inter-cluster mTLS connections establish using SWAP PKI certificates; K3s internal PKI is not exposed across cluster boundaries.
+- Default-deny `NetworkPolicy` is enforced in every namespace; only explicitly allowed traffic flows.
+- All pods pass Pod Security Standards `restricted` profile validation (except documented DaemonSet exceptions).
+- K3s `--secrets-encryption` is verified active on all clusters via `k3s secrets-encrypt status`.
+- SWAP nftables rules and kube-proxy rules coexist without chain collisions (validated by startup check).
+- Headlamp is accessible per-cluster; Rancher (when deployed) registers and manages all four clusters.
+- Helm charts install cleanly with `helm install --dry-run` against all target environments.
+- Storage classes (`local-path` for dev, `longhorn` for production) provision volumes successfully for StatefulSet workloads.

--- a/docs/deploy/k3s_infrastructure_spec.md
+++ b/docs/deploy/k3s_infrastructure_spec.md
@@ -8,7 +8,7 @@
 
 ## Non-Goals
 - Running all SWAP components in a single monolithic cluster.
-- Using a managed Kubernetes service (EKS, GKE, AKS); this spec targets bare-metal and VM deployments.
+- Using a managed Kubernetes service; this spec targets bare-metal and VM deployments.
 - Replacing the SWAP PKI with K3s internal PKI -- the two remain separate (see `docs/security/pki_enrollment_spec.md`).
 - Prescribing specific hardware; node sizing is left to capacity-planning documentation.
 

--- a/docs/deploy/single_image_spec.md
+++ b/docs/deploy/single_image_spec.md
@@ -1,5 +1,9 @@
 # SPEC: Single Docker Image Deployment (Embedded Auth Store)
 
+> **Status: Legacy / Single-Node Fallback.**
+> For production multi-cluster deployments, see [K3s Infrastructure Spec](./k3s_infrastructure_spec.md).
+> This spec remains valid for edge/minimal single-node deployments.
+
 ## Goals
 - Deliver the application as a single hardened Docker image (no SSH, no proxies), with an embedded encrypted auth store.
 
@@ -17,6 +21,7 @@ flowchart LR
 ```
 
 ## Detailed Design
+- Base image: `alpine:3.22` runtime with musl-linked static binary (multi-stage build from `rust:1-bookworm`).
 - Process: non-root user, read-only filesystem, cap-drop=ALL, tmpfs for `/tmp` and `/run`.
 - TLS: self-signed on first run if enabled; weekly rotation on restart.
 - Auth: default admin created on first run; password printed once to logs and to `/app/auth/INITIAL_ADMIN.txt` (0600); must change on first login.

--- a/docs/network/site_gateway_spec.md
+++ b/docs/network/site_gateway_spec.md
@@ -28,5 +28,9 @@ flowchart LR
 ## Operations
 - HA pair per site; monitoring and upgrade procedures; IP allowlists between sites.
 
+## K3s Deployment Note
+
+In K3s-based deployments, the DMZ cluster (`swap-dmz`) is the preferred implementation of the site gateway concept. The DMZ cluster runs Traefik as reverse proxy with Coraza WAF and terminates external TLS before forwarding to the Core cluster over mTLS. This spec remains valid for non-K3s bare-agent deployments where a dedicated gateway binary is preferred. See [K3s Infrastructure Spec](../deploy/k3s_infrastructure_spec.md).
+
 ## Acceptance Criteria
 - Defined protocols and relay behaviors; optional deployment guide.

--- a/docs/ops/observability_metrics_spec.md
+++ b/docs/ops/observability_metrics_spec.md
@@ -31,5 +31,15 @@ flowchart LR
 ## Acceptance Criteria
 - Metrics list documented; health/readiness semantics defined; tracing fields standardized.
 
+## K3s Multi-Cluster Observability
+
+In K3s deployments, observability runs in a dedicated Monitoring/Obs cluster (`swap-monitoring`):
+- **Prometheus federation**: Each cluster runs a local Prometheus instance; the Monitoring cluster federates metrics from Core, DMZ, and ETL clusters over mTLS.
+- **Grafana**: Centralized in the Monitoring cluster with datasources pointing to the federation endpoint.
+- **Alertmanager**: Centralized in the Monitoring cluster; receives alerts from all federated Prometheus instances.
+- **Loki**: Log aggregation from all clusters via Promtail DaemonSets shipping to the Monitoring cluster's Loki endpoint over mTLS.
+
+See [K3s Infrastructure Spec](../deploy/k3s_infrastructure_spec.md) for cluster topology details.
+
 ## Open Questions
 - Per-tenant metrics segmentation.

--- a/docs/ops/supply_chain_release_spec.md
+++ b/docs/ops/supply_chain_release_spec.md
@@ -30,5 +30,12 @@ flowchart LR
 ## Operations
 - Release versioning and changelog; rollback procedures.
 
+## OCI and Helm Chart Signing (K3s Deployments)
+
+- **OCI image signing**: Alpine 3.22-based container images are signed with cosign using keyless (Fulcio) or key-pair mode; signatures stored in the OCI registry alongside the image.
+- **Helm chart signing**: Charts are signed with `helm package --sign` using GPG keys; provenance files (`.prov`) distributed alongside chart tarballs.
+- **Verification**: K3s nodes verify image signatures via cosign policy before pulling; Helm chart provenance verified before install/upgrade.
+- **SBOM**: Generated during multi-stage build and attached as OCI artifact alongside the signed image.
+
 ## Acceptance Criteria
 - Supply chain steps documented; artifacts signed and verifiable; SBOM available.

--- a/docs/ops/upgrades_spec.md
+++ b/docs/ops/upgrades_spec.md
@@ -26,6 +26,13 @@ flowchart LR
 ## Security Posture
 - All artifacts signed; verification enforced before apply; audit logged.
 
+## K3s Upgrade Strategy
+
+- **K3s node upgrades**: Use Rancher's `system-upgrade-controller` with `Plan` CRDs for automated, staged K3s version upgrades across clusters.
+- **Application upgrades**: Helm version bumps applied via `helm upgrade` or Rancher Fleet GitOps (commit new chart version to Git; Fleet syncs automatically).
+- **Coordinated rollouts**: Rancher Fleet `ClusterGroup` targets allow rolling upgrades across clusters in sequence (Core first, then DMZ/ETL/Monitoring) with health gates between stages.
+- **Rollback**: `helm rollback` for application; `system-upgrade-controller` Plan revision for K3s; Rancher Fleet Git revert for GitOps-managed rollouts.
+
 ## Operations
 - Maintenance windows; rate limits on upgrades; observability on success/failure.
 

--- a/docs/security/secrets_management_spec.md
+++ b/docs/security/secrets_management_spec.md
@@ -26,5 +26,14 @@ flowchart LR
 ## Operations
 - Secret owners and rotation cadence documented; audit of secret access.
 
+## Kubernetes Secrets (K3s Deployments)
+
+- **K3s secrets encryption**: K3s is configured with `--secrets-encryption` to encrypt Secrets at rest in etcd using AES-CBC or AES-GCM.
+- **Kubernetes Secrets as source**: Application pods mount secrets via `secretRef` environment variables or volume mounts; secrets are created by operators or CI/CD pipelines.
+- **External Secrets Operator** (optional): For production deployments, `external-secrets-operator` syncs secrets from Vault, AWS Secrets Manager, or other backends into Kubernetes Secrets, providing a single abstraction layer.
+- **Rotation**: External Secrets Operator handles rotation by re-syncing from the backend on a configurable interval; pods pick up new secrets via rolling restart or projected volume refresh.
+
+See [K3s Infrastructure Spec](../deploy/k3s_infrastructure_spec.md) for cluster-level security configuration.
+
 ## Acceptance Criteria
 - Secrets flows documented; rotation procedures exist; integration points with KMS/Vault identified.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,41 @@
+site_name: SWAP — Secure Web Application Platform
+site_description: Hardened security orchestration with K3s multi-cluster deployment
+site_url: https://alistairhendersoninfo.github.io/secure-web-application/
+repo_url: https://github.com/alistairhendersoninfo/secure-web-application
+
+docs_dir: site
+site_dir: site_build
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: cyan
+  features:
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Features: features.md
+  - Architecture: architecture.md
+  - Getting Started: getting-started.md
+  - Specs:
+      - Deployment (K3s): specs/k3s-infrastructure.md
+      - Deployment (Single Image): specs/single-image.md
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - toc:
+      permalink: true

--- a/prompt.md
+++ b/prompt.md
@@ -207,6 +207,8 @@ Resilience
 - Single-binary controller (Rust) + single-binary agents (Rust). Systemd units with hardened settings (ProtectSystem, PrivateTmp, NoNewPrivileges, CapabilityBoundingSet, AmbientCapabilities minimal).
 - Backup/restore: encrypted snapshots of the controller DB and append-only audit log.
 - Upgrades: signed binaries; blue/green or canary deploy; automatic agent upgrades via signed packages with staged rollout.
+- **Primary production deployment target: K3s on Alpine 3.22** with a hybrid multi-cluster topology (Core, DMZ, ETL/Data, Monitoring/Obs clusters). Headlamp provides per-cluster local management UI; Rancher serves as fleet manager across clusters. See [K3s Infrastructure Spec](docs/deploy/k3s_infrastructure_spec.md) for full details.
+- The single-binary/systemd model remains valid for edge and minimal deployments where Kubernetes is not warranted.
 
 ## 16) Initial Deliverables and Milestones
 

--- a/site/architecture.md
+++ b/site/architecture.md
@@ -1,0 +1,81 @@
+# Architecture
+
+## Overview
+
+SWAP uses a multi-cluster K3s topology to enforce strict network isolation between trust zones. Each cluster runs its own control plane, CNI (Cilium), and etcd — there is no shared overlay network.
+
+```mermaid
+flowchart TB
+  subgraph mgmt["Rancher Management"]
+    R[Rancher Server]
+  end
+
+  subgraph core["Core / Internal K3s"]
+    CTRL[Controller]
+    AUTH[Auth Store]
+    PG[PostgreSQL]
+    AMGMT[Agent Management]
+    PREG[Plugin Registry]
+  end
+
+  subgraph dmz["DMZ K3s"]
+    TF[Traefik Reverse Proxy]
+    WAF[Coraza WAF]
+    TLS_T[TLS Termination]
+  end
+
+  subgraph etl["ETL / Data K3s"]
+    LIW[Log Ingestion Workers]
+    TJ[Transformation Jobs]
+  end
+
+  subgraph obs["Monitoring / Obs K3s"]
+    PROM[Prometheus]
+    GRAF[Grafana]
+    AM[Alertmanager]
+    LOKI[Loki]
+  end
+
+  R -->|manages| core
+  R -->|manages| dmz
+  R -->|manages| etl
+  R -->|manages| obs
+
+  dmz -->|mTLS| core
+  core -->|mTLS| etl
+  core -->|mTLS| obs
+  etl -->|mTLS| obs
+```
+
+## Technology Stack
+
+| Layer | Technology | Purpose |
+|-------|-----------|---------|
+| **Runtime** | K3s | Lightweight Kubernetes distribution |
+| **CNI** | Cilium | eBPF-based networking + network policies |
+| **Ingress** | Traefik | Reverse proxy with Coraza WAF sidecar |
+| **Identity** | SPIFFE/SPIRE | Workload identity + mTLS certificates |
+| **Certificates** | cert-manager | Automated certificate lifecycle |
+| **Storage** | Longhorn | Distributed block storage for StatefulSets |
+| **Fleet** | Rancher Fleet | GitOps multi-cluster management |
+| **Language** | Rust | All SWAP services compiled as musl-static binaries |
+| **Images** | Alpine 3.22 | Minimal runtime base image |
+
+## Container Image Pipeline
+
+All SWAP images follow a two-stage build:
+
+1. **Builder stage** — `rust:1.87-alpine3.22` compiles the binary with `RUSTFLAGS='-C target-feature=+crt-static'`
+2. **Runtime stage** — `alpine:3.22` with only the static binary, CA certificates, and a non-root user
+
+No shell, no package manager, no debugging tools in production images.
+
+## Inter-Cluster Communication
+
+Clusters communicate over routable IPs with mTLS. There is no shared overlay network or VPN tunnel. Each cluster's Cilium CNI manages its own pod network independently.
+
+Cross-cluster traffic is restricted by:
+
+- Cilium `CiliumNetworkPolicy` on egress
+- Firewall rules on the host network
+- mTLS certificate validation (SPIFFE trust domain per cluster)

--- a/site/features.md
+++ b/site/features.md
@@ -1,0 +1,44 @@
+# Features
+
+## Security-First Architecture
+
+SWAP is designed from the ground up with security as the primary concern, not an afterthought.
+
+### Mutual TLS Everywhere
+
+All inter-service and inter-cluster communication uses mTLS with SPIFFE-based workload identity. No plaintext traffic, no shared secrets — every connection is authenticated and encrypted.
+
+### Hardened Container Images
+
+All production images use Alpine 3.22 with musl-static Rust binaries. No shell, no package manager, no unnecessary utilities in the runtime image. Images are signed and verified through a supply-chain attestation pipeline.
+
+### Network Isolation
+
+Four dedicated K3s clusters enforce network-level isolation between trust zones:
+
+| Cluster | Purpose | Trust Level |
+|---------|---------|-------------|
+| **DMZ** | Public-facing ingress, WAF, TLS termination | Lowest — internet-exposed |
+| **Core** | Controller, auth, PostgreSQL, agent management | Highest — internal only |
+| **ETL/Data** | Log ingestion, transformation, storage | Medium — receives external data |
+| **Monitoring** | Prometheus, Grafana, Alertmanager, Loki | Medium — observes all clusters |
+
+## Plugin System
+
+SWAP supports WebAssembly plugins for extensible security tooling. Plugins run in a sandboxed WASM runtime with capability-based permissions, limiting what each plugin can access.
+
+## Agent Management
+
+Distributed security agents connect to the SWAP control plane for:
+
+- Centralized policy distribution
+- Log collection and forwarding
+- Health monitoring and alerting
+- Remote configuration updates
+
+## Operational Tooling
+
+- **Rancher Fleet** — GitOps-driven multi-cluster management
+- **Headlamp** — Per-cluster Kubernetes dashboard
+- **Prometheus Federation** — Unified metrics across all clusters
+- **Loki** — Centralized log aggregation

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -1,0 +1,65 @@
+# Getting Started
+
+## Prerequisites
+
+- 4+ Linux nodes (bare-metal or VMs) with routable IPs between them
+- SSH access to all nodes
+- `helm` v3.14+
+- `kubectl` v1.31+
+- `k3sup` for cluster bootstrapping
+
+## Quick Start
+
+### 1. Bootstrap the Core Cluster
+
+```bash
+# Install K3s on the core node
+k3sup install \
+  --ip <CORE_NODE_IP> \
+  --user root \
+  --k3s-extra-args '--disable=traefik --flannel-backend=none'
+
+# Install Cilium CNI
+helm install cilium cilium/cilium \
+  --namespace kube-system \
+  --set operator.replicas=1
+```
+
+### 2. Deploy SWAP Core Services
+
+```bash
+# Add the SWAP Helm chart
+helm install swap-core deploy/k3s/charts/swap-core \
+  --namespace swap-system \
+  --create-namespace \
+  --values deploy/k3s/charts/swap-core/values.yaml
+```
+
+### 3. Bootstrap Additional Clusters
+
+Repeat the K3s installation for DMZ, ETL, and Monitoring nodes, then deploy the corresponding Helm charts:
+
+```bash
+helm install swap-dmz deploy/k3s/charts/swap-dmz --namespace swap-system --create-namespace
+helm install swap-etl deploy/k3s/charts/swap-etl --namespace swap-system --create-namespace
+helm install swap-monitoring deploy/k3s/charts/swap-monitoring --namespace swap-system --create-namespace
+```
+
+### 4. Configure Rancher Fleet (Optional)
+
+```bash
+# Install Rancher on the management cluster
+helm install rancher rancher-latest/rancher \
+  --namespace cattle-system \
+  --create-namespace \
+  --set hostname=rancher.your-domain.com
+
+# Apply fleet configuration
+kubectl apply -f deploy/k3s/rancher/fleet.yaml
+```
+
+## Next Steps
+
+- Review the [K3s Infrastructure Spec](specs/k3s-infrastructure.md) for full deployment details
+- See [Architecture](architecture.md) for the multi-cluster topology
+- Check [Features](features.md) for platform capabilities

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,20 @@
+# SWAP — Secure Web Application Platform
+
+**Hardened security orchestration with K3s multi-cluster deployment.**
+
+SWAP is a security-first platform for deploying, managing, and monitoring distributed security agents across infrastructure. Built in Rust with mTLS everywhere, SWAP provides a hardened control plane for security operations.
+
+## Why SWAP?
+
+- **Zero-trust networking** — mTLS between all components, SPIFFE identity for workloads
+- **Multi-cluster isolation** — Four dedicated K3s clusters separate trust zones (DMZ, Core, ETL, Monitoring)
+- **Minimal attack surface** — Alpine 3.22 musl-static binaries, no shells in production images
+- **Plugin architecture** — WebAssembly plugin system for extensible security tooling
+- **GitOps-native** — Rancher Fleet for declarative multi-cluster management
+
+## Quick Links
+
+- [Features](features.md) — What SWAP provides
+- [Architecture](architecture.md) — How it's built
+- [Getting Started](getting-started.md) — Deploy your first cluster
+- [K3s Infrastructure Spec](specs/k3s-infrastructure.md) — Full deployment specification

--- a/site/specs/k3s-infrastructure.md
+++ b/site/specs/k3s-infrastructure.md
@@ -1,0 +1,22 @@
+# K3s Infrastructure Deployment Spec
+
+For the full specification, see [`docs/deploy/k3s_infrastructure_spec.md`](https://github.com/alistairhendersoninfo/secure-web-application/blob/main/docs/deploy/k3s_infrastructure_spec.md) in the repository.
+
+## Summary
+
+This specification defines a production-grade K3s deployment topology for SWAP across four isolated cluster zones:
+
+- **Core/Internal** — Controller, Auth Store, PostgreSQL, Agent Management, Plugin Registry
+- **DMZ** — Traefik ingress, Coraza WAF, TLS termination (only public-facing cluster)
+- **ETL/Data** — Log ingestion workers, transformation jobs, MinIO (optional)
+- **Monitoring/Obs** — Prometheus (federated), Grafana, Alertmanager, Loki
+
+An optional Rancher management cluster provides fleet-level visibility and GitOps configuration.
+
+## Key Design Decisions
+
+- **Alpine 3.22** base images with musl-static Rust binaries (no Distroless)
+- **Cilium CNI** with eBPF for network policies (no kube-proxy)
+- **Separate control planes** per cluster — no shared etcd or overlay
+- **mTLS everywhere** using SPIFFE workload identity
+- **Longhorn** for distributed block storage on StatefulSets

--- a/site/specs/k3s-infrastructure.md
+++ b/site/specs/k3s-infrastructure.md
@@ -1,6 +1,6 @@
 # K3s Infrastructure Deployment Spec
 
-For the full specification, see [`docs/deploy/k3s_infrastructure_spec.md`](https://github.com/alistairhendersoninfo/secure-web-application/blob/main/docs/deploy/k3s_infrastructure_spec.md) in the repository.
+For the full specification, see `docs/deploy/k3s_infrastructure_spec.md` in the repository.
 
 ## Summary
 

--- a/site/specs/single-image.md
+++ b/site/specs/single-image.md
@@ -1,0 +1,9 @@
+# Single Image Deployment Spec
+
+For the full specification, see [`docs/deploy/single_image_spec.md`](https://github.com/alistairhendersoninfo/secure-web-application/blob/main/docs/deploy/single_image_spec.md) in the repository.
+
+## Summary
+
+The single-image deployment packages all SWAP components into a single container for development, testing, and small-scale deployments. This is the simplest way to run SWAP but is not recommended for production use.
+
+For production deployments, see the [K3s Infrastructure Spec](k3s-infrastructure.md).


### PR DESCRIPTION
## Summary

- **K3s Infrastructure Spec** — Full deployment specification for 4-zone multi-cluster topology (Core, DMZ, ETL, Monitoring) with Rancher Fleet management
- **Helm Charts** — Charts for all 4 clusters (`deploy/k3s/charts/`) plus Rancher Fleet configuration
- **mkdocs-material Site** — GitHub Pages site with marketing/docs pages (`site/`, `mkdocs.yml`, updated `pages.yml` workflow)
- **Internal Docs** — `.docs/` with 4 ADRs (K3s over Docker, Alpine over Distroless, multi-cluster topology, Headlamp+Rancher), project context, and PR workflow docs
- **Spec Updates** — Existing specs updated for K3s migration compatibility

## Test plan

- [ ] CI passes (lint, codespell, mermaid validation)
- [ ] mkdocs builds successfully in Pages workflow
- [ ] Helm chart structure validates (`helm lint deploy/k3s/charts/*`)
- [ ] All markdown links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)